### PR TITLE
Frameless window w/ features (Winapi)

### DIFF
--- a/src/Chromely.CefGlue.Winapi/BrowserWindow/WinapiNativeWindow.cs
+++ b/src/Chromely.CefGlue.Winapi/BrowserWindow/WinapiNativeWindow.cs
@@ -17,6 +17,7 @@ using WinApi.DwmApi;
 using WinApi.Gdi32;
 using WinApi.Kernel32;
 using WinApi.User32;
+using Xilium.CefGlue;
 // ReSharper disable UnusedMember.Global
 
 namespace Chromely.CefGlue.Winapi.BrowserWindow
@@ -68,6 +69,8 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         {
             while (User32Methods.GetMessage(out Message msg, IntPtr.Zero, 0, 0) != 0)
             {
+                CefRuntime.DoMessageLoopWork();
+
                 User32Methods.TranslateMessage(ref msg);
                 User32Methods.DispatchMessage(ref msg);
             }
@@ -327,7 +330,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         internal static IntPtr HitTestNCA(IntPtr hWnd, IntPtr wParam, IntPtr lParam)
         {
             // Get the point coordinates for the hit test.
-            Point mousePoint = new Point(lParam.ToInt32() >> 16, lParam.ToInt32() & 0xFFFF);
+            Point mousePoint = new Point(lParam.ToInt32() & 0xFFFF, lParam.ToInt32() >> 16);
 
             // Get the window rectangle.
             Rectangle rectWindow;

--- a/src/Chromely.CefGlue.Winapi/BrowserWindow/WinapiNativeWindow.cs
+++ b/src/Chromely.CefGlue.Winapi/BrowserWindow/WinapiNativeWindow.cs
@@ -13,6 +13,7 @@ using Chromely.Core;
 using Chromely.Core.Host;
 using Chromely.Core.Infrastructure;
 using NetCoreEx.Geometry;
+using WinApi.DwmApi;
 using WinApi.Gdi32;
 using WinApi.Kernel32;
 using WinApi.User32;
@@ -266,6 +267,17 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
             var msg = (WM)umsg;
             switch (msg)
             {
+                case WM.ACTIVATE:
+                    {
+                        if (mHostConfig.HostFrameless)
+                        {
+                            Margins frameMargins = new Margins(7, 7, 27, 7);
+                            DwmApiMethods.DwmExtendFrameIntoClientArea(Handle, ref frameMargins);
+                            User32Methods.SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, WindowPositionFlags.SWP_NOZORDER | WindowPositionFlags.SWP_NOOWNERZORDER | WindowPositionFlags.SWP_NOMOVE | WindowPositionFlags.SWP_NOSIZE | WindowPositionFlags.SWP_FRAMECHANGED);
+                        }
+                        break;
+                    }
+
                 case WM.CREATE:
                     {
                         Handle = hwnd;
@@ -290,9 +302,74 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
                         Exit();
                         break;
                     }
+
+                case WM.NCCALCSIZE:
+                    {
+                        if (mHostConfig.HostFrameless)
+                        {
+                            return IntPtr.Zero;
+                        }
+                        break;
+                    }
+
+                case WM.NCHITTEST:
+                    {
+                        // This might be a bit redundant to perform and should find another way
+                        // to pass the return value rather than performing a hit test again.
+                        var lRet = HitTestNCA(hwnd, wParam, lParam);
+                        return lRet;
+                    }
             }
 
             return User32Methods.DefWindowProc(hwnd, umsg, wParam, lParam);
+        }
+
+        internal static IntPtr HitTestNCA(IntPtr hWnd, IntPtr wParam, IntPtr lParam)
+        {
+            // Get the point coordinates for the hit test.
+            Point mousePoint = new Point(lParam.ToInt32() >> 16, lParam.ToInt32() & 0xFFFF);
+
+            // Get the window rectangle.
+            Rectangle rectWindow;
+            User32Methods.GetWindowRect(hWnd, out rectWindow);
+
+            // Get the frame rectangle, adjusted for the style without a caption.
+            Rectangle rectFrame = new Rectangle(4, 4, 27, 4);
+            User32Methods.AdjustWindowRectEx(ref rectFrame, WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION, false, 0);
+            ushort row = 1;
+            ushort col = 1;
+            bool onTopResizeBorder = false;
+
+            // Determine if the point is at the top or bottom of the window.
+            if (mousePoint.Y >= rectWindow.Top && mousePoint.Y < rectWindow.Top + 27)
+            {
+                onTopResizeBorder = (mousePoint.Y < (rectWindow.Top - rectFrame.Top));
+                row = 0;
+            }
+            else if (mousePoint.Y < rectWindow.Bottom && mousePoint.Y >= rectWindow.Bottom - 7)
+            {
+                row = 2;
+            }
+
+            // Determine if the point is at the left or right of the window.
+            if (mousePoint.X >= rectWindow.Left && mousePoint.X < rectWindow.Left + 7)
+            {
+                col = 0;
+            }
+            else if (mousePoint.X < rectWindow.Right && mousePoint.X >= rectWindow.Right - 7)
+            {
+                col = 2;
+            }
+
+            // Defines the tests to determine what value to return for NCHITTEST
+            int[,] hitTests =
+            {
+                { 13, onTopResizeBorder ? 12 : 2, 11 },
+                { 10, 0, 11 },
+                { 16, 15, 17 }
+            };
+
+            return (IntPtr)hitTests[row, col];
         }
 
         /// <summary>
@@ -311,8 +388,8 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
 
             if (mHostConfig.HostFrameless)
             {
-                styles = WindowStyles.WS_POPUPWINDOW | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_CLIPSIBLINGS;
-                exStyles = WindowExStyles.WS_EX_TOOLWINDOW;
+                styles = WindowStyles.WS_CAPTION | WindowStyles.WS_POPUP | WindowStyles.WS_THICKFRAME | WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_MAXIMIZEBOX | WindowStyles.WS_CAPTION | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_CLIPSIBLINGS;
+                //exStyles = WindowExStyles.WS_EX_TOOLWINDOW;
             }
 
             switch (state)

--- a/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
@@ -354,7 +354,7 @@ namespace Chromely.CefGlue.BrowserWindow
             
             var settings = new CefSettings
             {
-                MultiThreadedMessageLoop = true,
+                MultiThreadedMessageLoop = false, // MultiThreadedMessageLoop is not allowed to be used as it will break frameless mode
                 LogSeverity = (CefLogSeverity)HostConfig.LogSeverity,
                 LogFile = HostConfig.LogFile,
                 ResourcesDirPath = Path.GetDirectoryName(

--- a/src/Chromely.CefSharp.Winapi/Browser/Handlers/CefSharpDragHandler.cs
+++ b/src/Chromely.CefSharp.Winapi/Browser/Handlers/CefSharpDragHandler.cs
@@ -1,0 +1,52 @@
+﻿using CefSharp;
+using CefSharp.Enums;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Chromely.CefSharp.Winapi.Browser.Handlers
+{
+    internal class CefSharpDragHandler : IDragHandler
+    {
+        public Region DragRegion = new Region();
+
+        public bool OnDragEnter(IWebBrowser chromiumWebBrowser, IBrowser browser, IDragData dragData, DragOperationsMask mask)
+        {
+            return false;
+        }
+
+        public void OnDraggableRegionsChanged(IWebBrowser chromiumWebBrowser, IBrowser browser, IList<DraggableRegion> regions)
+        {
+            if (!browser.IsPopup)
+            {
+                lock (DragRegion)
+                {
+                    DragRegion = null;
+                    foreach (var region in regions)
+                    {
+                        var rect = new Rectangle(region.X, region.Y, region.Width, region.Height);
+
+                        if (DragRegion == null)
+                        {
+                            DragRegion = new Region(rect);
+                        }
+                        else
+                        {
+                            if (region.Draggable)
+                            {
+                                DragRegion.Union(rect);
+                            }
+                            else
+                            {
+                                DragRegion.Exclude(rect);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Chromely.CefSharp.Winapi/Browser/Internals/InternalWebBrowserExtensions.cs
+++ b/src/Chromely.CefSharp.Winapi/Browser/Internals/InternalWebBrowserExtensions.cs
@@ -31,7 +31,6 @@ namespace Chromely.CefSharp.Winapi.Browser.Internals
             browser.LifeSpanHandler = null;
             browser.KeyboardHandler = null;
             browser.JsDialogHandler = null;
-            browser.DragHandler = null;
             browser.DownloadHandler = null;
             browser.MenuHandler = null;
             browser.FocusHandler = null;

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
@@ -344,7 +344,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                             {
                                 LocalesDirPath = localesDirPath,
                                 Locale = HostConfig.Locale,
-                                MultiThreadedMessageLoop = true,
+                                MultiThreadedMessageLoop = false, // MultiThreadedMessageLoop is not allowed to be used as it will break frameless mode
                                 CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Cache"),
                                 LogSeverity = (CefSharpGlobal.LogSeverity)HostConfig.LogSeverity,
                                 LogFile = HostConfig.LogFile

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
@@ -331,7 +331,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         internal static IntPtr HitTestNCA(IntPtr hWnd, IntPtr wParam, IntPtr lParam)
         {
             // Get the point coordinates for the hit test.
-            Point mousePoint = new Point(lParam.ToInt32() >> 16, lParam.ToInt32() & 0xFFFF);
+            Point mousePoint = new Point(lParam.ToInt32() & 0xFFFF, lParam.ToInt32() >> 16);
 
             // Get the window rectangle.
             Rectangle rectWindow;

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
@@ -275,7 +275,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                     {
                         if (mHostConfig.HostFrameless)
                         {
-                            Margins frameMargins = new Margins(7, 7, 27, 7);
+                            Margins frameMargins = new Margins(4, 4, 4, 4);
                             DwmApiMethods.DwmExtendFrameIntoClientArea(Handle, ref frameMargins);
                             User32Methods.SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, WindowPositionFlags.SWP_NOZORDER | WindowPositionFlags.SWP_NOOWNERZORDER | WindowPositionFlags.SWP_NOMOVE | WindowPositionFlags.SWP_NOSIZE | WindowPositionFlags.SWP_FRAMECHANGED);
                         }
@@ -338,29 +338,27 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             User32Methods.GetWindowRect(hWnd, out rectWindow);
 
             // Get the frame rectangle, adjusted for the style without a caption.
-            Rectangle rectFrame = new Rectangle(4, 4, 27, 4);
+            Rectangle rectFrame = new Rectangle(4, 4, 4, 4);
             User32Methods.AdjustWindowRectEx(ref rectFrame, WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION, false, 0);
             ushort row = 1;
             ushort col = 1;
-            bool onTopResizeBorder = false;
 
             // Determine if the point is at the top or bottom of the window.
-            if (mousePoint.Y >= rectWindow.Top && mousePoint.Y < rectWindow.Top + 27)
+            if (mousePoint.Y >= rectWindow.Top && mousePoint.Y < rectWindow.Top + 4)
             {
-                onTopResizeBorder = (mousePoint.Y < (rectWindow.Top - rectFrame.Top));
                 row = 0;
             }
-            else if (mousePoint.Y < rectWindow.Bottom && mousePoint.Y >= rectWindow.Bottom - 7)
+            else if (mousePoint.Y < rectWindow.Bottom && mousePoint.Y >= rectWindow.Bottom - 4)
             {
                 row = 2;
             }
 
             // Determine if the point is at the left or right of the window.
-            if (mousePoint.X >= rectWindow.Left && mousePoint.X < rectWindow.Left + 7)
+            if (mousePoint.X >= rectWindow.Left && mousePoint.X < rectWindow.Left + 4)
             {
                 col = 0;
             }
-            else if (mousePoint.X < rectWindow.Right && mousePoint.X >= rectWindow.Right - 7)
+            else if (mousePoint.X < rectWindow.Right && mousePoint.X >= rectWindow.Right - 4)
             {
                 col = 2;
             }
@@ -368,7 +366,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             // Defines the tests to determine what value to return for NCHITTEST
             int[,] hitTests =
             {
-                { 13, onTopResizeBorder ? 12 : 2, 11 },
+                { 13, 12, 11 },
                 { 10, 0, 11 },
                 { 16, 15, 17 }
             };

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
@@ -311,11 +311,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                     {
                         if (mHostConfig.HostFrameless)
                         {
-                            // Reasoning for checking wParam is listed here https://docs.microsoft.com/en-us/windows/desktop/winmsg/wm-nccalcsize
-                            if (wParam.ToInt32() > 0)
-                            {
-                                return IntPtr.Zero;
-                            }
+                            return IntPtr.Zero;
                         }
                         break;
                     }

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
@@ -16,7 +16,9 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
     using Core;
     using Core.Host;
     using Core.Infrastructure;
+    using global::CefSharp;
     using NetCoreEx.Geometry;
+    using WinApi.DwmApi;
     using WinApi.Gdi32;
     using WinApi.Kernel32;
     using WinApi.User32;
@@ -68,6 +70,8 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         {
             while (User32Methods.GetMessage(out Message msg, IntPtr.Zero, 0, 0) != 0)
             {
+                Cef.DoMessageLoopWork();
+
                 User32Methods.TranslateMessage(ref msg);
                 User32Methods.DispatchMessage(ref msg);
             }
@@ -267,6 +271,17 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             var msg = (WM)umsg;
             switch (msg)
             {
+                case WM.ACTIVATE:
+                    {
+                        if (mHostConfig.HostFrameless)
+                        {
+                            Margins frameMargins = new Margins(7, 7, 27, 7);
+                            DwmApiMethods.DwmExtendFrameIntoClientArea(Handle, ref frameMargins);
+                            User32Methods.SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, WindowPositionFlags.SWP_NOZORDER | WindowPositionFlags.SWP_NOOWNERZORDER | WindowPositionFlags.SWP_NOMOVE | WindowPositionFlags.SWP_NOSIZE | WindowPositionFlags.SWP_FRAMECHANGED);
+                        }
+                        break;
+                    }
+
                 case WM.CREATE:
                     {
                         Handle = hwnd;
@@ -291,9 +306,78 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                         Exit();
                         break;
                     }
+
+                case WM.NCCALCSIZE:
+                    {
+                        if (mHostConfig.HostFrameless)
+                        {
+                            // Reasoning for checking wParam is listed here https://docs.microsoft.com/en-us/windows/desktop/winmsg/wm-nccalcsize
+                            if (wParam.ToInt32() > 0)
+                            {
+                                return IntPtr.Zero;
+                            }
+                        }
+                        break;
+                    }
+
+                case WM.NCHITTEST:
+                    {
+                        // This might be a bit redundant to perform and should find another way
+                        // to pass the return value rather than performing a hit test again.
+                        var lRet = HitTestNCA(hwnd, wParam, lParam);
+                        return lRet;
+                    }
             }
 
             return User32Methods.DefWindowProc(hwnd, umsg, wParam, lParam);
+        }
+
+        internal static IntPtr HitTestNCA(IntPtr hWnd, IntPtr wParam, IntPtr lParam)
+        {
+            // Get the point coordinates for the hit test.
+            Point mousePoint = new Point(lParam.ToInt32() >> 16, lParam.ToInt32() & 0xFFFF);
+
+            // Get the window rectangle.
+            Rectangle rectWindow;
+            User32Methods.GetWindowRect(hWnd, out rectWindow);
+
+            // Get the frame rectangle, adjusted for the style without a caption.
+            Rectangle rectFrame = new Rectangle(4, 4, 27, 4);
+            User32Methods.AdjustWindowRectEx(ref rectFrame, WindowStyles.WS_OVERLAPPEDWINDOW & ~WindowStyles.WS_CAPTION, false, 0);
+            ushort row = 1;
+            ushort col = 1;
+            bool onTopResizeBorder = false;
+
+            // Determine if the point is at the top or bottom of the window.
+            if (mousePoint.Y >= rectWindow.Top && mousePoint.Y < rectWindow.Top + 27)
+            {
+                onTopResizeBorder = (mousePoint.Y < (rectWindow.Top - rectFrame.Top));
+                row = 0;
+            }
+            else if (mousePoint.Y < rectWindow.Bottom && mousePoint.Y >= rectWindow.Bottom - 7)
+            {
+                row = 2;
+            }
+
+            // Determine if the point is at the left or right of the window.
+            if (mousePoint.X >= rectWindow.Left && mousePoint.X < rectWindow.Left + 7)
+            {
+                col = 0;
+            }
+            else if (mousePoint.X < rectWindow.Right && mousePoint.X >= rectWindow.Right - 7)
+            {
+                col = 2;
+            }
+
+            // Defines the tests to determine what value to return for NCHITTEST
+            int[,] hitTests =
+            {
+                { 13, onTopResizeBorder ? 12 : 2, 11 },
+                { 10, 0, 11 },
+                { 16, 15, 17 }
+            };
+
+            return (IntPtr)hitTests[row, col];
         }
 
         /// <summary>
@@ -312,8 +396,8 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
 
             if (mHostConfig.HostFrameless)
             {
-                styles = WindowStyles.WS_POPUPWINDOW | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_CLIPSIBLINGS;
-                exStyles = WindowExStyles.WS_EX_TOOLWINDOW;
+                styles = WindowStyles.WS_CAPTION | WindowStyles.WS_POPUP | WindowStyles.WS_THICKFRAME | WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_MAXIMIZEBOX | WindowStyles.WS_CAPTION | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_CLIPSIBLINGS;
+                //exStyles = WindowExStyles.WS_EX_TOOLWINDOW;
             }
 
             switch (state)

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/Window.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/Window.cs
@@ -10,8 +10,11 @@
 namespace Chromely.CefSharp.Winapi.BrowserWindow
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
-
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading;
     using Chromely.CefSharp.Winapi.Browser;
     using Chromely.CefSharp.Winapi.Browser.Handlers;
     using Chromely.CefSharp.Winapi.Browser.Internals;
@@ -19,6 +22,9 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
     using Chromely.Core.Infrastructure;
 
     using global::CefSharp;
+    using NetCoreEx.Geometry;
+    using WinApi.DwmApi;
+    using WinApi.User32;
 
 
     /// <summary>
@@ -35,6 +41,13 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// The ChromiumWebBrowser object.
         /// </summary>
         private ChromiumWebBrowser mBrowser;
+
+        private IntPtr mBrowserHandle;
+        private IntPtr mBrowserWndProc;
+        private IntPtr mBrowserRenderWidgetHandle;
+        private IntPtr mBrowserRenderWidgetWndProc;
+        private List<ChildWindow> childWindows;
+        private List<WndProcOverride> wndProcOverrides = new List<WndProcOverride>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Window"/> class.
@@ -127,6 +140,58 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             mApplication.Quit();
         }
 
+        private delegate bool EnumWindowProc(IntPtr hWnd, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool EnumChildWindows(IntPtr window, EnumWindowProc callback, IntPtr lParam);
+
+        private struct ChildWindow
+        {
+            public IntPtr Handle;
+            public string ClassName;
+        }
+
+        private class EnumChildWindowsDetails
+        {
+            public List<ChildWindow> Windows = new List<ChildWindow>();
+        }
+
+        private class WndProcOverride
+        {
+            private IntPtr handle;
+            private IntPtr originalWndProc;
+            private string className;
+            private WindowProc newWndProc;
+
+            public WndProcOverride(IntPtr wndHandle, string wndClassName)
+            {
+                handle = wndHandle;
+                className = wndClassName;
+                newWndProc = new WindowProc(OverridenWndProc);
+                originalWndProc = User32Methods.SetWindowLongPtr(handle, -4, Marshal.GetFunctionPointerForDelegate(newWndProc));
+            }
+
+            private IntPtr OverridenWndProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam)
+            {
+                var msg = (WM)uMsg;
+                var originalRet = User32Methods.CallWindowProc(originalWndProc, hWnd, uMsg, wParam, lParam);
+                switch (msg)
+                {
+                    case WM.NCHITTEST:
+                        {
+                            // If we hit a non client area (our overlapped frame) then we'll force an NCHITTEST to bubble back up to the main process
+                            IntPtr hitTest = HitTestNCA(hWnd, wParam, lParam);
+                            if (hitTest != IntPtr.Zero) {
+                                return new IntPtr(-1);
+                            }
+                            break;
+                        }
+                }
+                return originalRet;
+            }
+        }
+
         /// <summary>
         /// Browser initialized changed event handler.
         /// </summary>
@@ -143,7 +208,41 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                 var size = GetClientSize();
                 mBrowser.SetSize(size.Width, size.Height);
                 mBrowser.IsBrowserInitializedChanged -= IsBrowserInitializedChanged;
+
+                mBrowserHandle = mBrowser.GetBrowserHost().GetWindowHandle();
+
+                var childWindowsDetails = new EnumChildWindowsDetails();
+                var gcHandle = GCHandle.Alloc(childWindowsDetails);
+                EnumChildWindows(Handle, new EnumWindowProc(EnumWindow), GCHandle.ToIntPtr(gcHandle));
+
+                foreach(ChildWindow childWindow in childWindowsDetails.Windows)
+                {
+                    var wndProcOverride = new WndProcOverride(childWindow.Handle, childWindow.ClassName);
+                    wndProcOverrides.Add(wndProcOverride);
+                }
+
+                childWindows = childWindowsDetails.Windows;
+
+                gcHandle.Free();
             }
+        }
+
+        private bool EnumWindow(IntPtr hWnd, IntPtr lParam)
+        {
+            var buffer = new StringBuilder(128);
+            User32Methods.GetClassName(hWnd, buffer, buffer.Capacity);
+
+            var childWindow = new ChildWindow()
+            {
+                Handle = hWnd,
+                ClassName = buffer.ToString()
+            };
+
+            var gcHandleDetails = GCHandle.FromIntPtr(lParam);
+            var details = (EnumChildWindowsDetails)gcHandleDetails.Target;
+            details.Windows.Add(childWindow);
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Going from issue #81 I was very interested in learning this more as the current frameless implementation is very limited and rendered useless at the moment as you can't resize or even drag the window. I have since added this implementation successfully.

*Note: All border margins may not be ideal and can be adjusted, especially for CefGlue.Winapi*

### Current Implementation
- **CefSharp.Winapi** has full proper frameless window with resize, aero snap, and ability to drag the window by setting elements with `-webkit-app-region: drag`. This has the full frameless window experience Electron has.
- **CefGlue.Winapi (Partial)** currently has a frameless window with the ability to resize, aero snap, and drag the window but **canot** be modified with `-webkit-app-region: drag` as .NETStandard has some missing System.Drawing classes. Border margins currently not adjustable to suit the needs of individual apps. Should I add an API for this? It might be a quick to obselete method until a solution can be figured out for `-webkit-app-region`.

I do not expect this PR to be merged right away as it is not a full flawless implementation yet.