### PR TITLE
Added Kiosk mode for cefglue winapi.

### DIFF
--- a/src/Chromely.CefGlue.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefGlue.Winapi/BrowserWindow/NativeWindow.cs
@@ -26,6 +26,8 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
     /// </summary>
     internal class NativeWindow
     {
+        private static readonly NativeMethods.LowLevelKeyboardProc _hookCallback = HookCallback;
+
         /// <summary>
         /// The host config.
         /// </summary>
@@ -35,6 +37,8 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         /// WindowProc ref : prevent GC Collect
         /// </summary>
         private WindowProc _windowProc;
+
+        private IntPtr _hookID = IntPtr.Zero;
         
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeWindow"/> class.
@@ -68,7 +72,16 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         {
             while (User32Methods.GetMessage(out Message msg, IntPtr.Zero, 0, 0) != 0)
             {
-                if (ChromelyConfiguration.Instance.HostFrameless)
+                if (msg.Value == (uint)WM.CLOSE)
+                {
+                    DetachKeyboardHook();
+                }
+
+                if (ChromelyConfiguration.Instance.KioskMode && msg.Value == (uint)WM.HOTKEY && msg.WParam == (IntPtr)1)
+                {
+                    User32Methods.PostMessage(NativeWindow.NativeInstance.Handle, (uint)WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
+                }
+                if (ChromelyConfiguration.Instance.HostFrameless || ChromelyConfiguration.Instance.KioskMode)
                 {
                     CefRuntime.DoMessageLoopWork();
                 }
@@ -211,7 +224,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
             var instanceHandle = Kernel32Methods.GetModuleHandle(IntPtr.Zero);
 
             _windowProc = WindowProc;
-            
+
             var wc = new WindowClassEx
             {
                 Size = (uint)Marshal.SizeOf<WindowClassEx>(),
@@ -260,9 +273,121 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
                 return;
             }
 
-            User32Methods.ShowWindow(Handle, styles.Item3);
+            if (_hostConfig.KioskMode)
+            {
+                //// Set new window style and size.
+                //var styles = GetWindowStyles(WindowState.Normal);
+                var windowHDC = User32Methods.GetDC(Handle);
+                var fullscreenWidth =  Gdi32Methods.GetDeviceCaps(windowHDC, (int)DeviceCapsParams.HORZRES);
+                var fullscreenHeight = Gdi32Methods.GetDeviceCaps(windowHDC, (int)DeviceCapsParams.VERTRES);
+                User32Methods.ReleaseDC(Handle, windowHDC);
+
+                User32Methods.SetWindowLongPtr(Handle, (int)WindowLongFlags.GWL_STYLE, (IntPtr)styles.Item1);
+                User32Methods.SetWindowLongPtr(Handle, (int)WindowLongFlags.GWL_EXSTYLE, (IntPtr)styles.Item2);
+
+
+                User32Methods.SetWindowPos(Handle, (IntPtr)HwndZOrder.HWND_TOPMOST, 0, 0, fullscreenWidth, fullscreenHeight,
+                    WindowPositionFlags.SWP_NOZORDER | WindowPositionFlags.SWP_NOACTIVATE | WindowPositionFlags.SWP_FRAMECHANGED);
+
+                User32Methods.ShowWindow(Handle, ShowWindowCommands.SW_MAXIMIZE);
+
+                try
+                {
+                    this._hookID = NativeMethods.SetHook(_hookCallback);
+                }
+                catch
+                {
+                    DetachKeyboardHook();
+                }
+            }
+            else
+            {
+                User32Methods.ShowWindow(Handle, styles.Item3);
+            }
             User32Methods.UpdateWindow(Handle);
+
+            User32Methods.RegisterHotKey(IntPtr.Zero, 1, KeyModifierFlags.MOD_CONTROL, VirtualKey.L);
+
         }
+        
+        public static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode >= 0)
+            {
+
+                var msg = (WM)wParam;
+                var hookInfo = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);
+
+                var key = (VirtualKey)hookInfo.vkCode;
+
+
+
+                bool alt = User32Methods.GetKeyState(VirtualKey.MENU).IsPressed;
+                bool control = User32Methods.GetKeyState(VirtualKey.CONTROL).IsPressed;             
+
+                //if (alt && key == VirtualKey.F4)
+                //{
+                //    Application.Current.Shutdown();
+                //    return (IntPtr)1; // Handled.
+                //}
+
+                if (!AllowKeyboardInput(alt, control, key))
+                {
+                    return (IntPtr)1; // Handled.
+                }
+            }
+
+            return NativeMethods.CallNextHookEx(NativeInstance._hookID, nCode, wParam, lParam);
+        }
+
+        /// <summary>Determines whether the specified keyboard input should be allowed to be processed by the system.</summary>
+        /// <remarks>Helps block unwanted keys and key combinations that could exit the app, make system changes, etc.</remarks>
+        public static bool AllowKeyboardInput(bool alt, bool control, VirtualKey key)
+        {
+            // Disallow various special keys.
+            if (key <= VirtualKey.BACK || key == VirtualKey.NONAME ||
+                key == VirtualKey.MENU || key == VirtualKey.PAUSE ||
+                key == VirtualKey.HELP)
+            {
+                return false;
+            }
+
+            // Disallow ranges of special keys.
+            // Currently leaves volume controls enabled; consider if this makes sense.
+            // Disables non-existing Keys up to 65534, to err on the side of caution for future keyboard expansion.
+            if ((key >= VirtualKey.LWIN && key <= VirtualKey.SLEEP) ||
+                (key >= VirtualKey.KANA && key <= VirtualKey.HANJA) ||
+                (key >= VirtualKey.CONVERT && key <= VirtualKey.MODECHANGE) ||
+                //(key >= VirtualKey.BROWSER_BACK && key <= VirtualKey.BROWSER_HOME) ||
+                (key >= VirtualKey.MEDIA_NEXT_TRACK && key <= VirtualKey.LAUNCH_APP2) ||
+                (key >= VirtualKey.PROCESSKEY && key <= (VirtualKey)65534))
+            {
+                return false;
+            }
+
+            // Disallow specific key combinations. (These component keys would be OK on their own.)
+            if ((alt && key == VirtualKey.TAB) ||
+                (alt && key == VirtualKey.SPACE) ||
+                (control && key == VirtualKey.ESCAPE))
+            {
+                return false;
+            }
+
+            // Allow anything else (like letters, numbers, spacebar, braces, and so on).
+            return true;
+        }
+
+        /// <summary>
+        /// Detach the keyboard hook; call during shutdown to prevent calls as we unload
+        /// </summary>
+        private static void DetachKeyboardHook()
+        {
+            if (NativeInstance._hookID != IntPtr.Zero)
+                NativeMethods.UnhookWindowsHookEx(NativeInstance._hookID);
+        }
+
+
+        internal static NativeWindow NativeInstance { get; set; }
 
         /// <summary>
         /// The window proc.
@@ -287,6 +412,23 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
             var msg = (WM)umsg;
             switch (msg)
             {
+                case WM.HOTKEY:
+                    {
+                        if (wParam == (IntPtr)1)
+                        {
+                            User32Methods.PostMessage(Handle, (uint)WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
+                            return IntPtr.Zero;
+                        }
+                        break;
+                    }
+                case WM.SYSKEYDOWN:
+                    {
+                        if (_hostConfig.KioskMode &&  (wParam == (IntPtr)VirtualKey.F4))
+                        {
+                            return IntPtr.Zero;
+                        }
+                        break;
+                    }
                 case WM.ACTIVATE:
                     {
                         if (_hostConfig.HostFrameless)
@@ -295,11 +437,13 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
                             DwmApiMethods.DwmExtendFrameIntoClientArea(Handle, ref frameMargins);
                             User32Methods.SetWindowPos(hwnd, IntPtr.Zero, 0, 0, 0, 0, WindowPositionFlags.SWP_NOZORDER | WindowPositionFlags.SWP_NOOWNERZORDER | WindowPositionFlags.SWP_NOMOVE | WindowPositionFlags.SWP_NOSIZE | WindowPositionFlags.SWP_FRAMECHANGED);
                         }
+                        
                         break;
                     }
 
                 case WM.CREATE:
                     {
+                        NativeInstance = this;
                         Handle = hwnd;
                         var size = GetClientSize();
                         OnCreate(hwnd, size.Width, size.Height);
@@ -417,6 +561,12 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
                 styles = WindowStyles.WS_CAPTION | WindowStyles.WS_POPUP | WindowStyles.WS_THICKFRAME | WindowStyles.WS_MINIMIZEBOX | WindowStyles.WS_MAXIMIZEBOX | WindowStyles.WS_CAPTION | WindowStyles.WS_CLIPCHILDREN | WindowStyles.WS_CLIPSIBLINGS;
             }
 
+            if (_hostConfig.KioskMode)
+            {
+                styles &= ~(WindowStyles.WS_CAPTION | WindowStyles.WS_THICKFRAME);
+                exStyles &= ~(WindowExStyles.WS_EX_DLGMODALFRAME | WindowExStyles.WS_EX_WINDOWEDGE | WindowExStyles.WS_EX_CLIENTEDGE | WindowExStyles.WS_EX_STATICEDGE);
+            }
+
             switch (state)
             {
                 case WindowState.Normal:
@@ -432,6 +582,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
                 {
                     styles |= WindowStyles.WS_MAXIMIZE;
                     exStyles = WindowExStyles.WS_EX_TOOLWINDOW;
+                       
                     return new Tuple<WindowStyles, WindowExStyles, ShowWindowCommands>(styles, exStyles, ShowWindowCommands.SW_SHOWMAXIMIZED);
                 }
             }

--- a/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
@@ -371,7 +371,7 @@ namespace Chromely.CefGlue.BrowserWindow
                 ResourcesDirPath = Path.GetDirectoryName(new Uri(assembly.CodeBase).LocalPath)
             };
 
-            if (HostConfig.HostFrameless)
+            if (HostConfig.HostFrameless || HostConfig.KioskMode)
             {
                 if (HostConfig.HostApi == ChromelyHostApi.Gtk)
                 {

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
@@ -334,7 +334,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
                 Locale = HostConfig.Locale,
 
                 // MultiThreadedMessageLoop is not allowed to be used as it will break frameless mode
-                MultiThreadedMessageLoop = !HostConfig.HostFrameless,
+                MultiThreadedMessageLoop = !(HostConfig.HostFrameless || HostConfig.KioskMode),
 
                 CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CefSharp\\Cache"),
                 LogSeverity = (CefSharpGlobal.LogSeverity)HostConfig.LogSeverity,

--- a/src/Chromely.Core/ChromelyConfiguration.cs
+++ b/src/Chromely.Core/ChromelyConfiguration.cs
@@ -51,6 +51,7 @@ namespace Chromely.Core
             ShutdownCefOnExit = true;
             LogSeverity = LogSeverity.Warning;
             LogFile = Path.Combine("logs", "chromely.cef.log");
+            KioskMode = false;
             HostState = WindowState.Normal;
             HostCenterScreen = true;
             UseDefaultSubprocess = ChromelyRuntime.Platform == ChromelyPlatform.Windows;
@@ -114,6 +115,11 @@ namespace Chromely.Core
         /// Gets or sets a value indicating whether host to not display borders, minimize, maximize and close.
         /// </summary>
         public bool HostFrameless { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display in fullscreen, topmost and disable ALT+F4 and ALT+Tab global hotkeys.
+        /// </summary>
+        public bool KioskMode { get; set; }
 
         /// <summary>
         /// Gets or sets the host/window/app title.
@@ -382,6 +388,23 @@ namespace Chromely.Core
         public ChromelyConfiguration WithFramelessHost(bool frameless = true)
         {
             HostFrameless = frameless;
+            return this;
+        }
+
+        /// <summary>
+        /// Set frameless host mode.
+        /// </summary>
+        /// <param name="kiosk"></param>
+        /// The <see cref="ChromelyConfiguration"/>.
+        public ChromelyConfiguration WithKioskMode(bool kiosk = true)
+        {
+            KioskMode = kiosk;
+            if (this.KioskMode)
+            {
+                this.WithHostMode(WindowState.Normal, false)
+                    .WithFramelessHost(false);
+
+            }
             return this;
         }
 


### PR DESCRIPTION
Added Kiosk mode for cefglue winapi, that is full-screen and intercepts all interrupting input like Alt+Tab, Win key and other such friends.

Also current implementation adds ctrl+L shortcut to be able somehow close window :) @mattkol please give me some advice,where and how to put extensibility point to be able define custom global hooks

The current full-screen mode doesn't hide taskbar in my case :(.

My full-screen implementation is based on [this ](https://stackoverflow.com/questions/2382464/win32-full-screen-and-hiding-taskbar)stackoverflow answer, which is based on Chromium's full-screen implementation.



