### PR TITLE
Non static IoC container. (Preparation of work for Custom IoC containers )

### DIFF
--- a/src/Chromely.CefGlue.Winapi/BrowserWindow/CefGlueWindow.cs
+++ b/src/Chromely.CefGlue.Winapi/BrowserWindow/CefGlueWindow.cs
@@ -18,7 +18,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
     /// </summary>
     internal class CefGlueWindow : HostBase
     {
-        private IWindow _mainWindow;
+        private Window _mainWindow;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueWindow"/> class.
@@ -59,7 +59,8 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         /// </summary>
         protected override void RunMessageLoop()
         {
-            NativeWindow.RunMessageLoop();
+            _mainWindow.RunMessageLoop();
+            //NativeWindow.RunMessageLoop();
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         /// </summary>
         protected override void QuitMessageLoop()
         {
-            NativeWindow.Exit();
+            _mainWindow.Exit();
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefGlue.Winapi/BrowserWindow/NativeWindow.cs
@@ -64,11 +64,11 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         /// <summary>
         /// The run message loop.
         /// </summary>
-        public static void RunMessageLoop()
+        public virtual void RunMessageLoop()
         {
             while (User32Methods.GetMessage(out Message msg, IntPtr.Zero, 0, 0) != 0)
             {
-                if (ChromelyConfiguration.Instance.HostFrameless)
+                if (this._hostConfig.HostFrameless)
                 {
                     CefRuntime.DoMessageLoopWork();
                 }
@@ -81,7 +81,7 @@ namespace Chromely.CefGlue.Winapi.BrowserWindow
         /// <summary>
         /// The exit.
         /// </summary>
-        public static void Exit()
+        public virtual void Exit()
         {
             User32Methods.PostQuitMessage(0);
         }

--- a/src/Chromely.CefGlue/Browser/CefGlueApp.cs
+++ b/src/Chromely.CefGlue/Browser/CefGlueApp.cs
@@ -31,7 +31,7 @@ namespace Chromely.CefGlue.Browser
         /// <summary>
         /// The browser process handler.
         /// </summary>
-        private readonly CefBrowserProcessHandler _browserProcessHandler = new CefGlueBrowserProcessHandler();
+        private readonly CefBrowserProcessHandler _browserProcessHandler;
         
         /// <summary>
         /// The host config.
@@ -47,6 +47,7 @@ namespace Chromely.CefGlue.Browser
         public CefGlueApp(ChromelyConfiguration hostConfig)
         {
             _hostConfig = hostConfig;
+            _browserProcessHandler = new CefGlueBrowserProcessHandler(hostConfig);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Chromely.CefGlue.Browser
         /// </param>
         protected override void OnRegisterCustomSchemes(CefSchemeRegistrar registrar)
         {
-            var schemeHandlerObjs = IoC.GetAllInstances(typeof(ChromelySchemeHandler));
+            var schemeHandlerObjs = this._hostConfig.IoCContainer.GetAllInstances(typeof(ChromelySchemeHandler));
             if (schemeHandlerObjs != null)
             {
                 var schemeHandlers = schemeHandlerObjs.ToList();

--- a/src/Chromely.CefGlue/Browser/CefGlueBrowser.cs
+++ b/src/Chromely.CefGlue/Browser/CefGlueBrowser.cs
@@ -22,10 +22,6 @@ namespace Chromely.CefGlue.Browser
     /// </summary>
     public class CefGlueBrowser
     {
-        /// <summary>
-        /// The host config.
-        /// </summary>
-        private readonly ChromelyConfiguration _hostConfig;
 
         /// <summary>
         /// The CefBrowserSettings object.
@@ -57,7 +53,7 @@ namespace Chromely.CefGlue.Browser
         public CefGlueBrowser(object owner, ChromelyConfiguration hostConfig, CefBrowserSettings settings)
         {
             Owner = owner;
-            _hostConfig = hostConfig;
+            HostConfig = hostConfig;
             _settings = settings;
             StartUrl = hostConfig.StartUrl;
         }
@@ -136,25 +132,25 @@ namespace Chromely.CefGlue.Browser
 
         #endregion Events Handling Properties
 
-        /// <summary>
-        /// Gets the browser core.
-        /// </summary>
-        public static CefGlueBrowser BrowserCore
-        {
-            get
-            {
-                if (IoC.IsRegistered(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName))
-                {
-                    var instance = IoC.GetInstance(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName);
-                    if (instance is CefGlueBrowser browser)
-                    {
-                        return browser;
-                    }
-                }
+        ///// <summary>
+        ///// Gets the browser core.
+        ///// </summary>
+        //public static CefGlueBrowser BrowserCore
+        //{
+        //    get
+        //    {
+        //        if (IoC.IsRegistered(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName))
+        //        {
+        //            var instance = IoC.GetInstance(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName);
+        //            if (instance is CefGlueBrowser browser)
+        //            {
+        //                return browser;
+        //            }
+        //        }
 
-                return null;
-            }
-        }
+        //        return null;
+        //    }
+        //}
 
         /// <summary>
         /// Gets the owner.
@@ -182,6 +178,11 @@ namespace Chromely.CefGlue.Browser
         public CefBrowser CefBrowser { get; private set; }
 
         /// <summary>
+        /// Browser host configuration
+        /// </summary>
+        public ChromelyConfiguration HostConfig { get; }
+
+        /// <summary>
         /// The create.
         /// </summary>
         /// <param name="windowInfo">
@@ -191,8 +192,8 @@ namespace Chromely.CefGlue.Browser
         {
             if (_client == null)
             {
-                IoC.RegisterInstance(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName, this);
-                _client = new CefGlueClient(CefGlueClientParams.Create(this));
+                this.HostConfig.IoCContainer.RegisterInstance(typeof(CefGlueBrowser), typeof(CefGlueBrowser).FullName, this);
+                _client = new CefGlueClient(CefGlueClientParams.Create(this, this.HostConfig));
             }
             if (_settings == null)
             {
@@ -254,7 +255,7 @@ namespace Chromely.CefGlue.Browser
 
             // Register browser 
             CefGlueFrameHandler frameHandler = new CefGlueFrameHandler(browser);
-            IoC.RegisterInstance(typeof(CefGlueFrameHandler), typeof(CefGlueFrameHandler).FullName, frameHandler);
+            this.HostConfig.IoCContainer.RegisterInstance(typeof(CefGlueFrameHandler), typeof(CefGlueFrameHandler).FullName, frameHandler);
 
             StartWebsocket();
             Created?.Invoke(this, EventArgs.Empty);
@@ -425,9 +426,9 @@ namespace Chromely.CefGlue.Browser
         {
             try
             {
-                if (_hostConfig.StartWebSocket)
+                if (HostConfig.StartWebSocket)
                 {
-                    WebsocketServerRunner.StartServer(_hostConfig.WebsocketAddress, _hostConfig.WebsocketPort);
+                    WebsocketServerRunner.StartServer(HostConfig, HostConfig.WebsocketAddress, HostConfig.WebsocketPort);
                     _websocketStarted = true;
                 }
             }

--- a/src/Chromely.CefGlue/Browser/CefGlueBrowserExtension.cs
+++ b/src/Chromely.CefGlue/Browser/CefGlueBrowserExtension.cs
@@ -40,9 +40,9 @@ namespace Chromely.CefGlue.Browser
                     var keyStr = enumKey.EnumToString();
                     try
                     {
-                        if (IoC.IsRegistered(service, keyStr))
+                        if (browser.HostConfig.IoCContainer.IsRegistered(service, keyStr))
                         {
-                            instance = IoC.GetInstance(service, keyStr);
+                            instance = browser.HostConfig.IoCContainer.GetInstance(service, keyStr);
                         }
                     }
                     catch (Exception exception)

--- a/src/Chromely.CefGlue/Browser/CefGlueClient.cs
+++ b/src/Chromely.CefGlue/Browser/CefGlueClient.cs
@@ -7,6 +7,7 @@
 // </license>
 // ----------------------------------------------------------------------------------------------------------------------
 
+using Chromely.Core;
 using Chromely.Core.Infrastructure;
 using Xilium.CefGlue;
 using Xilium.CefGlue.Wrapper;
@@ -78,6 +79,9 @@ namespace Chromely.CefGlue.Browser
         /// </summary>
         private readonly CefFindHandler _findHandler;
 
+
+
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueClient"/> class.
         /// </summary>
@@ -86,6 +90,7 @@ namespace Chromely.CefGlue.Browser
         /// </param>
         public CefGlueClient(CefGlueClientParams clientParams)
         {
+            Config = clientParams.Config;
             CoreBrowser = clientParams.Browser;
             _lifeSpanHandler = clientParams.LifeSpanHandler;
             _loadHandler = clientParams.LoadHandler;
@@ -105,6 +110,12 @@ namespace Chromely.CefGlue.Browser
         /// Gets the core browser.
         /// </summary>
         public CefGlueBrowser CoreBrowser { get; }
+
+        /// <summary>
+        /// The Chromely host config
+        /// </summary>
+        public ChromelyConfiguration Config { get; }
+
 
         /// <summary>
         /// The get life span handler.
@@ -255,7 +266,7 @@ namespace Chromely.CefGlue.Browser
         /// </returns>
         protected override bool OnProcessMessageReceived(CefBrowser browser, CefProcessId sourceProcess, CefProcessMessage message)
         {
-            var browserMessageRouter = IoC.GetInstance<CefMessageRouterBrowserSide>(typeof(CefMessageRouterBrowserSide).FullName);
+            var browserMessageRouter = this.Config.IoCContainer.GetInstance<CefMessageRouterBrowserSide>(typeof(CefMessageRouterBrowserSide).FullName);
             return browserMessageRouter?.OnProcessMessageReceived(browser, sourceProcess, message) ?? false;
         }
     }

--- a/src/Chromely.CefGlue/Browser/CefGlueClientParams.cs
+++ b/src/Chromely.CefGlue/Browser/CefGlueClientParams.cs
@@ -87,17 +87,25 @@ namespace Chromely.CefGlue.Browser
         public CefFindHandler FindHandler { get; set; }
 
         /// <summary>
+        /// The Chromely host config
+        /// </summary>
+        public ChromelyConfiguration Config { get; private set; }
+
+
+
+        /// <summary>
         /// The create.
         /// </summary>
         /// <param name="browser">
         /// The browser.
         /// </param>
+        /// <param name="config">Chromely engine config</param>
         /// <returns>
         /// The <see cref="CefGlueClientParams"/>.
         /// </returns>
-        public static CefGlueClientParams Create(CefGlueBrowser browser)
+        public static CefGlueClientParams Create(CefGlueBrowser browser, ChromelyConfiguration config)
         {
-            var clientParams = new CefGlueClientParams { Browser = browser };
+            var clientParams = new CefGlueClientParams { Browser = browser, Config = config };
 
             try
             {
@@ -109,9 +117,9 @@ namespace Chromely.CefGlue.Browser
                     var keyStr = enumKey.EnumToString();
                     try
                     {
-                        if (IoC.IsRegistered(service, keyStr))
+                        if (config.IoCContainer.IsRegistered(service, keyStr))
                         {
-                            instance = IoC.GetInstance(service, keyStr);
+                            instance = config.IoCContainer.GetInstance(service, keyStr);
                         }
                     }
                     catch (Exception exception)
@@ -128,7 +136,7 @@ namespace Chromely.CefGlue.Browser
                             }
                             else
                             {
-                                clientParams.LifeSpanHandler = new CefGlueLifeSpanHandler();
+                                clientParams.LifeSpanHandler = new CefGlueLifeSpanHandler(config.IoCContainer.GetInstance<CefGlueBrowser>());
                             }
 
                             break;
@@ -140,7 +148,7 @@ namespace Chromely.CefGlue.Browser
                             }
                             else
                             {
-                                clientParams.LoadHandler = new CefGlueLoadHandler();
+                                clientParams.LoadHandler = new CefGlueLoadHandler(config.IoCContainer.GetInstance<CefGlueBrowser>());
                             }
 
                             break;
@@ -152,7 +160,7 @@ namespace Chromely.CefGlue.Browser
                             }
                             else
                             {
-                                clientParams.RequestHandler = new CefGlueRequestHandler();
+                                clientParams.RequestHandler = new CefGlueRequestHandler(config.IoCContainer.GetInstance<CefGlueBrowser>());
                             }
 
                             break;
@@ -164,7 +172,7 @@ namespace Chromely.CefGlue.Browser
                             }
                             else
                             {
-                                clientParams.DisplayHandler = new CefGlueDisplayHandler();
+                                clientParams.DisplayHandler = new CefGlueDisplayHandler(config.IoCContainer.GetInstance<CefGlueBrowser>());
                             }
 
                             break;
@@ -176,7 +184,7 @@ namespace Chromely.CefGlue.Browser
                             }
                             else
                             {
-                                clientParams.ContextMenuHandler = new CefGlueContextMenuHandler();
+                                clientParams.ContextMenuHandler = new CefGlueContextMenuHandler(config.DebuggingMode);
                             }
 
                             break;
@@ -218,7 +226,7 @@ namespace Chromely.CefGlue.Browser
                             {
                                 clientParams.DragHandler = dragHandler;
                             }
-                            else if (ChromelyConfiguration.Instance.HostFrameless)
+                            else if (config.HostFrameless)
                             {
                                 clientParams.DragHandler = new CefGlueDragHandler();
                             }
@@ -250,5 +258,6 @@ namespace Chromely.CefGlue.Browser
 
             return clientParams;
         }
+
     }
 }

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueBrowserProcessHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueBrowserProcessHandler.cs
@@ -22,6 +22,22 @@ namespace Chromely.CefGlue.Browser.Handlers
     /// </summary>
     public class CefGlueBrowserProcessHandler : CefBrowserProcessHandler
     {
+        private readonly ChromelyConfiguration _hostConfig;
+
+        /// <summary>
+        /// The constructor
+        /// </summary>
+        /// <param name="hostConfig">Host configruation</param>
+        public CefGlueBrowserProcessHandler(ChromelyConfiguration hostConfig)
+        {
+            _hostConfig = hostConfig;
+        }
+
+        /// <summary>
+        /// Host configuration
+        /// </summary>
+        public ChromelyConfiguration HostConfig => _hostConfig;
+
         /// <summary>
         /// The on before child process launch.
         /// </summary>
@@ -34,7 +50,7 @@ namespace Chromely.CefGlue.Browser.Handlers
             commandLine.AppendSwitch(SubprocessArguments.HostProcessIdArgument, Process.GetCurrentProcess().Id.ToString());
             commandLine.AppendSwitch(SubprocessArguments.ExitIfParentProcessClosed, "1");
 
-            var schemeHandlerObjs = IoC.GetAllInstances(typeof(ChromelySchemeHandler));
+            var schemeHandlerObjs = _hostConfig.IoCContainer.GetAllInstances(typeof(ChromelySchemeHandler));
             if (schemeHandlerObjs != null)
             {
                 var schemeHandlers = schemeHandlerObjs.ToList();
@@ -56,10 +72,10 @@ namespace Chromely.CefGlue.Browser.Handlers
             }
 
             // Get all custom command line argument switches
-            if (ChromelyConfiguration.Instance.CommandLineArgs != null)
+            if (_hostConfig.CommandLineArgs != null)
             {
                 var argument = string.Empty;
-                foreach (var commandArg in ChromelyConfiguration.Instance.CommandLineArgs)
+                foreach (var commandArg in _hostConfig.CommandLineArgs)
                 {
                     if (commandArg.Item3)
                     {
@@ -89,7 +105,7 @@ namespace Chromely.CefGlue.Browser.Handlers
             commandLine.AppendSwitch("disable-web-security");
             commandLine.AppendSwitch("ignore-certificate-errors");
 
-            if (ChromelyConfiguration.Instance.DebuggingMode)
+            if (_hostConfig.DebuggingMode)
             {
                 Console.WriteLine("On CefGlue child process launch arguments:");
                 Console.WriteLine(commandLine.ToString());

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueContextMenuHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueContextMenuHandler.cs
@@ -36,9 +36,9 @@ namespace Chromely.CefGlue.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueContextMenuHandler"/> class.
         /// </summary>
-        public CefGlueContextMenuHandler()
+        public CefGlueContextMenuHandler(bool debugging)
         {
-            debugging = ChromelyConfiguration.Instance.DebuggingMode;
+            this.debugging = debugging;
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueDisplayHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueDisplayHandler.cs
@@ -26,9 +26,9 @@ namespace Chromely.CefGlue.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueDisplayHandler"/> class.
         /// </summary>
-        public CefGlueDisplayHandler()
+        public CefGlueDisplayHandler(CefGlueBrowser browser)
         {
-            _browser = CefGlueBrowser.BrowserCore;
+            _browser = browser;
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueLifeSpanHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueLifeSpanHandler.cs
@@ -27,9 +27,9 @@ namespace Chromely.CefGlue.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueLifeSpanHandler"/> class.
         /// </summary>
-        public CefGlueLifeSpanHandler()
+        public CefGlueLifeSpanHandler(CefGlueBrowser browser)
         {
-            _browser = CefGlueBrowser.BrowserCore;
+            _browser = browser;
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueLoadHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueLoadHandler.cs
@@ -26,9 +26,9 @@ namespace Chromely.CefGlue.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueLoadHandler"/> class.
         /// </summary>
-        public CefGlueLoadHandler()
+        public CefGlueLoadHandler(CefGlueBrowser browser)
         {
-            _browser = CefGlueBrowser.BrowserCore;
+            _browser = browser;
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue/Browser/Handlers/CefGlueRequestHandler.cs
+++ b/src/Chromely.CefGlue/Browser/Handlers/CefGlueRequestHandler.cs
@@ -29,9 +29,9 @@ namespace Chromely.CefGlue.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefGlueRequestHandler"/> class.
         /// </summary>
-        public CefGlueRequestHandler()
+        public CefGlueRequestHandler(CefGlueBrowser browser)
         {
-            _browser = CefGlueBrowser.BrowserCore;
+            _browser = browser;
         }
 
         /// <summary>

--- a/src/Chromely.CefGlue/Browser/ServerHandlers/CefGlueServerHandler.cs
+++ b/src/Chromely.CefGlue/Browser/ServerHandlers/CefGlueServerHandler.cs
@@ -38,6 +38,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// The websocket handler.
         /// </summary>
         private readonly IChromelyWebsocketHandler _websocketHandler;
+        private readonly IChromelyContainer _chromelyContainer;
 
         /// <summary>
         /// The complete callback.
@@ -55,9 +56,11 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// <param name="websocketHandler">
         /// The websocket handler.
         /// </param>
-        public CefGlueServerHandler(IChromelyWebsocketHandler websocketHandler)
+        /// <param name="chromelyContainer">The Chromely IoC container</param>
+        public CefGlueServerHandler(IChromelyWebsocketHandler websocketHandler, IChromelyContainer chromelyContainer)
         {
             _websocketHandler = websocketHandler;
+            _chromelyContainer = chromelyContainer;
         }
 
         /// <summary>
@@ -203,7 +206,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
             {
                 ConnectionNameMapper.Clear();
                 _server = server;
-                IoC.RegisterInstance(typeof(CefServer), typeof(CefServer).FullName, _server);
+                _chromelyContainer.RegisterInstance(typeof(CefServer), typeof(CefServer).FullName, _server);
                 IsServerRunning = server.IsRunning;
                 RunCompleteCallback(server.IsRunning);
             }

--- a/src/Chromely.CefGlue/Browser/ServerHandlers/CefGlueWebsocketHandler.cs
+++ b/src/Chromely.CefGlue/Browser/ServerHandlers/CefGlueWebsocketHandler.cs
@@ -16,6 +16,7 @@ using Chromely.Core;
 using Chromely.Core.Infrastructure;
 using Chromely.Core.RestfulService;
 using LitJson;
+using Xilium.CefGlue;
 
 namespace Chromely.CefGlue.Browser.ServerHandlers
 {
@@ -24,6 +25,17 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
     /// </summary>
     public class CefGlueWebsocketHandler : IChromelyWebsocketHandler
     {
+        private readonly CefServer _cefServer;
+
+        /// <summary>
+        /// The constructor
+        /// </summary>
+        /// <param name="cefServer"></param>
+        public CefGlueWebsocketHandler(CefServer cefServer)
+        {
+            _cefServer = cefServer;
+        }
+
         /// <summary>
         /// The on message.
         /// </summary>
@@ -55,22 +67,22 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
                         switch (requestInfo.Type)
                         {
                             case MessageType.Echo:
-                                WebsocketMessageSender.Send(connectionId, requestInfo.Data);
+                                this._cefServer.Send(connectionId, requestInfo.Data);
                                 break;
                             case MessageType.TargetRecepient:
-                                WebsocketMessageSender.Send(requestInfo.TargetConnectionId, requestInfo.Data);
+                                this._cefServer.Send(requestInfo.TargetConnectionId, requestInfo.Data);
                                 break;
                             case MessageType.Broadcast:
-                                WebsocketMessageSender.Broadcast(connectionId, requestInfo.Data);
+                                this._cefServer.Broadcast(connectionId, requestInfo.Data);
                                 break;
                             case MessageType.ControllerAction:
                                 var jsonData = JsonMapper.ToObject<JsonData>(requestString);
                                 var request = new ChromelyRequest(jsonData);
                                 var response = RequestTaskRunner.Run(request);
-                                WebsocketMessageSender.Send(connectionId, response);
+                                this._cefServer.Send(connectionId, response);
                                 break;
                             default:
-                                WebsocketMessageSender.Send(connectionId, requestInfo.Data);
+                                this._cefServer.Send(connectionId, requestInfo.Data);
                                 break;
                         }
                     }
@@ -100,7 +112,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Send(int connectionId, IntPtr data, long dataSize)
         {
-            WebsocketMessageSender.Send(connectionId, data, dataSize);
+            this._cefServer.Send(connectionId, data, dataSize);
         }
 
         /// <summary>
@@ -114,7 +126,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Send(int connectionId, string data)
         {
-            WebsocketMessageSender.Send(connectionId, data);
+            this._cefServer.Send(connectionId, data);
         }
 
         /// <summary>
@@ -128,7 +140,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Send(int connectionId, ChromelyResponse response)
         {
-            WebsocketMessageSender.Send(connectionId, response);
+            this._cefServer.Send(connectionId, response);
         }
 
         /// <summary>
@@ -145,7 +157,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Broadcast(int connectionId, IntPtr data, long dataSize)
         {
-            WebsocketMessageSender.Broadcast(connectionId, data, dataSize);
+            this._cefServer.Broadcast(connectionId, data, dataSize);
         }
 
         /// <summary>
@@ -159,7 +171,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Broadcast(int connectionId, string data)
         {
-            WebsocketMessageSender.Broadcast(connectionId, data);
+            this._cefServer.Broadcast(connectionId, data);
         }
 
         /// <summary>
@@ -173,7 +185,7 @@ namespace Chromely.CefGlue.Browser.ServerHandlers
         /// </param>
         public void Broadcast(int connectionId, ChromelyResponse response)
         {
-            WebsocketMessageSender.Broadcast(connectionId, response);
+            this._cefServer.Broadcast(connectionId, response);
         }
     }
 }

--- a/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
@@ -264,9 +264,9 @@ namespace Chromely.CefGlue.BrowserWindow
             {
                 if (!assembly.IsScanned)
                 {
-                    var scanner = new RouteScanner(assembly.Assembly);
+                    var scanner = new RouteScanner(assembly.Assembly, HostConfig.IoCContainer);
                     var currentRouteDictionary = scanner.Scan();
-                    ServiceRouteProvider.MergeRoutes(currentRouteDictionary);
+                    this.HostConfig.IoCContainer.MergeRoutes(currentRouteDictionary);
 
                     assembly.IsScanned = true;
                 }
@@ -464,7 +464,7 @@ namespace Chromely.CefGlue.BrowserWindow
         private void RegisterSchemeHandlers()
         {
             // Register scheme handlers
-            var schemeHandlerObjs = IoC.GetAllInstances(typeof(ChromelySchemeHandler));
+            var schemeHandlerObjs = this.HostConfig.IoCContainer.GetAllInstances(typeof(ChromelySchemeHandler));
             if (schemeHandlerObjs != null)
             {
                 var schemeHandlers = schemeHandlerObjs.ToList();
@@ -505,10 +505,10 @@ namespace Chromely.CefGlue.BrowserWindow
             }
 
             BrowserMessageRouter = new CefMessageRouterBrowserSide(new CefMessageRouterConfig());
-            IoC.RegisterInstance(typeof(CefMessageRouterBrowserSide).FullName, BrowserMessageRouter);
+            this.HostConfig.IoCContainer.RegisterInstance(typeof(CefMessageRouterBrowserSide).FullName, BrowserMessageRouter);
 
             // Register message router handlers
-            var messageRouterHandlers = IoC.GetAllInstances(typeof(ChromelyMessageRouter)).ToList();
+            var messageRouterHandlers = this.HostConfig.IoCContainer.GetAllInstances(typeof(ChromelyMessageRouter)).ToList();
             if (messageRouterHandlers.Any())
             {
                 var routerHandlers = messageRouterHandlers.ToList();

--- a/src/Chromely.CefGlue/ChromelyConfigurationExtension.cs
+++ b/src/Chromely.CefGlue/ChromelyConfigurationExtension.cs
@@ -105,7 +105,7 @@ namespace Chromely.CefGlue
         {
             if (messageRouterHandler != null)
             {
-                IoC.RegisterInstance(typeof(ChromelyMessageRouter), messageRouterHandler.Key, messageRouterHandler);
+                configuration.IoCContainer.RegisterInstance(typeof(ChromelyMessageRouter), messageRouterHandler.Key, messageRouterHandler);
             }
 
             return configuration;
@@ -141,13 +141,13 @@ namespace Chromely.CefGlue
             }
 
             // Remove handler if exists - only one handler is allowed.
-            var isHandlerRegistered = IoC.IsRegistered<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName);
+            var isHandlerRegistered = configuration.IoCContainer.IsRegistered<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName);
             if (isHandlerRegistered)
             {
-                IoC.UnregisterHandler<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName);
+                configuration.IoCContainer.UnregisterHandler<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName);
             }
 
-            IoC.RegisterInstance(typeof(IChromelyWebsocketHandler), typeof(IChromelyWebsocketHandler).FullName, socketHandler);
+            configuration.IoCContainer.RegisterInstance(typeof(IChromelyWebsocketHandler), typeof(IChromelyWebsocketHandler).FullName, socketHandler);
 
             configuration.WebsocketAddress = address;
             configuration.WebsocketPort = port;

--- a/src/Chromely.CefGlue/FrameHandler.cs
+++ b/src/Chromely.CefGlue/FrameHandler.cs
@@ -8,6 +8,7 @@
 // ----------------------------------------------------------------------------------------------------------------------
 
 using Chromely.CefGlue.Browser.FrameHandlers;
+using Chromely.Core;
 using Chromely.Core.Infrastructure;
 using Xilium.CefGlue;
 
@@ -24,50 +25,29 @@ namespace Chromely.CefGlue
         private static CefBrowser _browser;
 
         /// <summary>
-        /// Gets the browser.
-        /// </summary>
-        private static CefBrowser Browser
-        {
-            get
-            {
-                if (_browser != null)
-                {
-                    return _browser;
-                }
-
-                var cefGlueFrameHandler = IoC.GetInstance<CefGlueFrameHandler>(typeof(CefGlueFrameHandler).FullName);
-                if (cefGlueFrameHandler != null)
-                {
-                    _browser = cefGlueFrameHandler.Browser;
-                }
-
-                return _browser;
-            }
-        }
-
-        /// <summary>
         /// The get main frame.
         /// </summary>
         /// <returns>
         /// The <see cref="CefFrame"/>.
         /// </returns>
-        public static CefFrame GetMainFrame()
+        public static CefFrame GetMainFrame(this IChromelyContainer container)
         {
-            return Browser?.GetMainFrame();
+            return container.GetBrowser()?.GetMainFrame();
         }
 
         /// <summary>
         /// The get frame.
         /// </summary>
+        /// <param name="container"></param>
         /// <param name="name">
         /// The name.
         /// </param>
         /// <returns>
         /// The <see cref="CefFrame"/>.
         /// </returns>
-        public static CefFrame GetFrame(string name)
+        public static CefFrame GetFrame(this IChromelyContainer container, string name)
         {
-            return Browser?.GetFrame(name);
+            return container.GetBrowser()?.GetFrame(name);
         }
 
         /// <summary>
@@ -76,9 +56,20 @@ namespace Chromely.CefGlue
         /// <returns>
         /// The <see cref="CefBrowser"/>.
         /// </returns>
-        public static CefBrowser GetBrowser()
+        public static CefBrowser GetBrowser(this IChromelyContainer container)
         {
-            return Browser;
+            if (_browser != null)
+            {
+                return _browser;
+            }
+
+            var cefGlueFrameHandler = container.GetInstance<CefGlueFrameHandler>(typeof(CefGlueFrameHandler).FullName);
+            if (cefGlueFrameHandler != null)
+            {
+                _browser = cefGlueFrameHandler.Browser;
+            }
+
+            return _browser;
         }
     }
 }

--- a/src/Chromely.CefGlue/Subprocess/Subprocess.cs
+++ b/src/Chromely.CefGlue/Subprocess/Subprocess.cs
@@ -35,9 +35,12 @@ namespace Chromely.CefGlue.Subprocess
         /// Executes the <see cref="Subprocess"/>.
         /// </summary>
         /// <param name="args"></param>
+        /// <param name="configuration">Host configucation</param>
         /// <returns></returns>
-        public static int Execute(string[] args)
+        public static int Execute(string[] args, ChromelyConfiguration configuration = null)
         {
+            var config = configuration ?? ChromelyConfiguration.Create();
+
             int result;
             var type = args.GetArgumentValue(SubprocessArguments.ArgumentType);
 
@@ -65,7 +68,7 @@ namespace Chromely.CefGlue.Subprocess
                 result = ExecuteProcess(args);
             }
 
-            if (ChromelyConfiguration.Instance.DebuggingMode)
+            if (config.DebuggingMode)
             {
                 Console.WriteLine("CefGlue Subprocess shutting down.");
             }

--- a/src/Chromely.CefGlue/WebsocketMessageSender.cs
+++ b/src/Chromely.CefGlue/WebsocketMessageSender.cs
@@ -65,42 +65,16 @@ namespace Chromely.CefGlue
         private static readonly object ObjLock8 = new object();
 
         /// <summary>
-        /// The cefserver.
-        /// </summary>
-        private static CefServer cefserver;
-
-        /// <summary>
-        /// Gets the browser.
-        /// </summary>
-        private static CefServer Server
-        {
-            get
-            {
-                if (cefserver != null)
-                {
-                    return cefserver;
-                }
-
-                var server = IoC.GetInstance<CefServer>(typeof(CefServer).FullName);
-                if (server != null)
-                {
-                    cefserver = server;
-                }
-
-                return server;
-            }
-        }
-
-        /// <summary>
         /// The send.
         /// </summary>
+        /// <param name="server">The Cef server</param>
         /// <param name="clientName">
         /// The client name.
         /// </param>
         /// <param name="response">
         /// The response.
         /// </param>
-        public static void Send(string clientName, ChromelyResponse response)
+        public static void Send(this CefServer server, string clientName, ChromelyResponse response)
         {
             lock (ObjLock1)
             {
@@ -116,13 +90,13 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
                     var jsonResponse = JsonMapper.ToJson(response);
-                    SendMessage(clientName, jsonResponse);
+                    SendMessage(server, clientName, jsonResponse);
                 }
                 catch (Exception exception)
                 {
@@ -134,13 +108,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send.
         /// </summary>
+        /// <param name="server">The Cef Server</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="response">
         /// The response.
         /// </param>
-        public static void Send(int connectionId, ChromelyResponse response)
+        public static void Send(this CefServer server, int connectionId, ChromelyResponse response)
         {
             lock (ObjLock2)
             {
@@ -156,13 +131,13 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
                     var jsonResponse = JsonMapper.ToJson(response);
-                    SendMessage(connectionId, jsonResponse);
+                    SendMessage(server, connectionId, jsonResponse);
                 }
                 catch (Exception exception)
                 {
@@ -174,13 +149,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="clientName">
         /// The client name.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        public static void Send(string clientName, string data)
+        public static void Send(this CefServer server, string clientName, string data)
         {
             lock (ObjLock3)
             {
@@ -196,12 +172,12 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
-                    SendMessage(clientName, data);
+                    SendMessage(server, clientName, data);
                 }
                 catch (Exception exception)
                 {
@@ -213,13 +189,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        public static void Send(int connectionId, string data)
+        public static void Send(this CefServer server, int connectionId, string data)
         {
             lock (ObjLock4)
             {
@@ -235,12 +212,12 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
-                    SendMessage(connectionId, data);
+                    SendMessage(server, connectionId, data);
                 }
                 catch (Exception exception)
                 {
@@ -252,6 +229,7 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
@@ -261,7 +239,7 @@ namespace Chromely.CefGlue
         /// <param name="dataSize">
         /// The data size.
         /// </param>
-        public static void Send(int connectionId, IntPtr data, long dataSize)
+        public static void Send(this CefServer server, int connectionId, IntPtr data, long dataSize)
         {
             lock (ObjLock5)
             {
@@ -272,12 +250,12 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
-                    SendMessage(connectionId, data, dataSize);
+                    SendMessage(server, connectionId, data, dataSize);
                 }
                 catch (Exception exception)
                 {
@@ -289,13 +267,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The broadcast.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="response">
         /// The response.
         /// </param>
-        public static void Broadcast(int connectionId, ChromelyResponse response)
+        public static void Broadcast(this CefServer server, int connectionId, ChromelyResponse response)
         {
             lock (ObjLock6)
             {
@@ -311,13 +290,13 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
 
                     var jsonResponse = JsonMapper.ToJson(response);
-                    BroadcastMessage(connectionId, jsonResponse);
+                    BroadcastMessage(server, connectionId, jsonResponse);
                 }
                 catch (Exception exception)
                 {
@@ -329,13 +308,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The broadcast.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        public static void Broadcast(int connectionId, string data)
+        public static void Broadcast(this CefServer server, int connectionId, string data)
         {
             lock (ObjLock7)
             {
@@ -351,7 +331,7 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    BroadcastMessage(connectionId, data);
+                    BroadcastMessage(server, connectionId, data);
                 }
                 catch (Exception exception)
                 {
@@ -363,6 +343,7 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The broadcast.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
@@ -372,7 +353,7 @@ namespace Chromely.CefGlue
         /// <param name="dataSize">
         /// The data size.
         /// </param>
-        public static void Broadcast(int connectionId, IntPtr data, long dataSize)
+        public static void Broadcast(this CefServer server, int connectionId, IntPtr data, long dataSize)
         {
             lock (ObjLock8)
             {
@@ -383,7 +364,7 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    BroadcastMessage(connectionId, data, dataSize);
+                    BroadcastMessage(server, connectionId, data, dataSize);
                 }
                 catch (Exception exception)
                 {
@@ -395,13 +376,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send message.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="clientName">
         /// The client name.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        private static void SendMessage(string clientName, string data)
+        private static void SendMessage(CefServer server, string clientName, string data)
         {
             Task.Run(() =>
             {
@@ -420,7 +402,7 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
@@ -429,7 +411,7 @@ namespace Chromely.CefGlue
                     outIntPtr = Marshal.AllocHGlobal(outputByte.Length);
                     Marshal.Copy(outputByte, 0, outIntPtr, outputByte.Length);
 
-                    Server.SendWebSocketMessage(connectionId, outIntPtr, outputByte.Length);
+                    server.SendWebSocketMessage(connectionId, outIntPtr, outputByte.Length);
                 }
                 catch (Exception exception)
                 {
@@ -446,13 +428,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send message.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        private static void SendMessage(int connectionId, string data)
+        private static void SendMessage(CefServer server, int connectionId, string data)
         {
             Task.Run(() =>
             {
@@ -465,7 +448,7 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
@@ -474,7 +457,7 @@ namespace Chromely.CefGlue
                     outIntPtr = Marshal.AllocHGlobal(outputByte.Length);
                     Marshal.Copy(outputByte, 0, outIntPtr, outputByte.Length);
 
-                    Server.SendWebSocketMessage(connectionId, outIntPtr, outputByte.Length);
+                    server.SendWebSocketMessage(connectionId, outIntPtr, outputByte.Length);
                 }
                 catch (Exception exception)
                 {
@@ -491,6 +474,7 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The send message.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
@@ -500,19 +484,19 @@ namespace Chromely.CefGlue
         /// <param name="dataSize">
         /// The data size.
         /// </param>
-        private static void SendMessage(int connectionId, IntPtr data, long dataSize)
+        private static void SendMessage(CefServer server, int connectionId, IntPtr data, long dataSize)
         {
             Task.Run(() =>
                 {
                     try
                     {
 
-                        if (Server == null)
+                        if (server == null)
                         {
                             return;
                         }
 
-                        Server.SendWebSocketMessage(connectionId, data, dataSize);
+                        server.SendWebSocketMessage(connectionId, data, dataSize);
                     }
                     catch (Exception exception)
                     {
@@ -524,13 +508,14 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The broadcast message.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
         /// <param name="data">
         /// The data.
         /// </param>
-        private static void BroadcastMessage(int connectionId, string data)
+        private static void BroadcastMessage(CefServer server, int connectionId, string data)
         {
             Task.Run(() =>
             {
@@ -559,7 +544,7 @@ namespace Chromely.CefGlue
                         return;
                     }
 
-                    if (Server == null)
+                    if (server == null)
                     {
                         return;
                     }
@@ -572,7 +557,7 @@ namespace Chromely.CefGlue
                     {
                         if (id != connectionId)
                         {
-                            Server.SendWebSocketMessage(id, outIntPtr, outputByte.Length);
+                            server.SendWebSocketMessage(id, outIntPtr, outputByte.Length);
                         }
                     }
                 }
@@ -591,6 +576,7 @@ namespace Chromely.CefGlue
         /// <summary>
         /// The broadcast message.
         /// </summary>
+        /// <param name="server">The CefServer</param>
         /// <param name="connectionId">
         /// The connection id.
         /// </param>
@@ -600,7 +586,7 @@ namespace Chromely.CefGlue
         /// <param name="dataSize">
         /// The data size.
         /// </param>
-        private static void BroadcastMessage(int connectionId, IntPtr data, long dataSize)
+        private static void BroadcastMessage(CefServer server, int connectionId, IntPtr data, long dataSize)
         {
             Task.Run(() =>
                 {
@@ -622,7 +608,7 @@ namespace Chromely.CefGlue
                             return;
                         }
 
-                        if (Server == null)
+                        if (server == null)
                         {
                             return;
                         }
@@ -631,7 +617,7 @@ namespace Chromely.CefGlue
                         {
                             if (id != connectionId)
                             {
-                                Server.SendWebSocketMessage(id, data, dataSize);
+                                server.SendWebSocketMessage(id, data, dataSize);
                             }
                         }
                     }

--- a/src/Chromely.CefGlue/WebsocketServerRunner.cs
+++ b/src/Chromely.CefGlue/WebsocketServerRunner.cs
@@ -11,6 +11,7 @@ using System;
 using Chromely.CefGlue.Browser.ServerHandlers;
 using Chromely.Core;
 using Chromely.Core.Infrastructure;
+using Xilium.CefGlue;
 
 namespace Chromely.CefGlue
 {
@@ -50,35 +51,36 @@ namespace Chromely.CefGlue
             }
         }
 
-        /// <summary>
-        /// The start server.
-        /// </summary>
-        public static void StartServer()
-        {
-            StartServer(0);
-        }
+        ///// <summary>
+        ///// The start server.
+        ///// </summary>
+        //public static void StartServer()
+        //{
+        //    StartServer(0);
+        //}
+
+        ///// <summary>
+        ///// The start server.
+        ///// </summary>
+        ///// <param name="port">
+        ///// The port.
+        ///// </param>
+        //public static void StartServer(int port)
+        //{
+        //    StartServer(string.Empty, port);
+        //}
 
         /// <summary>
         /// The start server.
         /// </summary>
-        /// <param name="port">
-        /// The port.
-        /// </param>
-        public static void StartServer(int port)
-        {
-            StartServer(string.Empty, port);
-        }
-
-        /// <summary>
-        /// The start server.
-        /// </summary>
+        /// <param name="config">The host configuration</param>
         /// <param name="address">
         /// The address.
         /// </param>
         /// <param name="port">
         /// The port.
         /// </param>
-        public static void StartServer(string address, int port)
+        public static void StartServer(ChromelyConfiguration config, string address, int port)
         {
             try
             {
@@ -92,11 +94,11 @@ namespace Chromely.CefGlue
                     return;
                 }
 
-                var sockeHandler = IoC.GetInstance<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName)
-                                   ?? new CefGlueWebsocketHandler();
+                var socketHandler = config.IoCContainer.GetInstance<IChromelyWebsocketHandler>(typeof(IChromelyWebsocketHandler).FullName)
+                                   ?? new CefGlueWebsocketHandler(config.IoCContainer.GetInstance<CefServer>());
 
                 ConnectionNameMapper.Clear();
-                _serverHandler = new CefGlueServerHandler(sockeHandler);
+                _serverHandler = new CefGlueServerHandler(socketHandler, config.IoCContainer);
                 _serverHandler.StartServer(Address, Port, OnStartServerComplete);
             }
             catch (Exception exception)

--- a/src/Chromely.CefSharp.Winapi/Browser/ChromiumWebBrowser.cs
+++ b/src/Chromely.CefSharp.Winapi/Browser/ChromiumWebBrowser.cs
@@ -10,6 +10,7 @@
 using System;
 using Chromely.CefSharp.Winapi.Browser.FrameHandlers;
 using Chromely.CefSharp.Winapi.Browser.Internals;
+using Chromely.Core;
 using Chromely.Core.Infrastructure;
 using global::CefSharp;
 using global::CefSharp.Internals;
@@ -21,6 +22,8 @@ namespace Chromely.CefSharp.Winapi.Browser
     /// </summary>
     internal class ChromiumWebBrowser : IWebBrowserInternal
     {
+        private readonly ChromelyConfiguration _config;
+
         /// <summary>
         /// The settings.
         /// </summary>
@@ -61,6 +64,7 @@ namespace Chromely.CefSharp.Winapi.Browser
         /// <summary>
         /// Initializes a new instance of the <see cref="ChromiumWebBrowser"/> class.
         /// </summary>
+        /// <param name="config">Chromley config</param>
         /// <param name="settings">
         /// The Settings.
         /// </param>
@@ -70,9 +74,10 @@ namespace Chromely.CefSharp.Winapi.Browser
         /// <param name="useLegacyJavascriptBindingEnabled">
         /// Flag to use whether Javascript binding should be used.
         /// </param>
-        public ChromiumWebBrowser(AbstractCefSettings settings, string address,  bool useLegacyJavascriptBindingEnabled = true)
+        public ChromiumWebBrowser(ChromelyConfiguration config, AbstractCefSettings settings, string address,  bool useLegacyJavascriptBindingEnabled = true)
         {
             Address = address;
+            _config = config;
             _settings = settings;
             CefSharpSettings.LegacyJavascriptBindingEnabled = useLegacyJavascriptBindingEnabled;
             InitializeFieldsAndCefIfRequired();
@@ -329,6 +334,8 @@ namespace Chromely.CefSharp.Winapi.Browser
         /// <value><c>true</c> if this instance has parent; otherwise, <c>false</c>.</value>
         bool IWebBrowserInternal.HasParent { get; set; }
 
+        public ChromelyConfiguration Config => _config;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ChromiumWebBrowser"/> class.
         /// </summary>
@@ -522,7 +529,7 @@ namespace Chromely.CefSharp.Winapi.Browser
 
             // Register browser 
             var frameHandler = new CefSharpFrameHandler(browser);
-            IoC.RegisterInstance(typeof(CefSharpFrameHandler), typeof(CefSharpFrameHandler).FullName, frameHandler);
+            this.Config.IoCContainer.RegisterInstance(typeof(CefSharpFrameHandler), typeof(CefSharpFrameHandler).FullName, frameHandler);
 
             IsBrowserInitializedChanged?.Invoke(this, new IsBrowserInitializedChangedEventArgs(IsBrowserInitialized));
         }

--- a/src/Chromely.CefSharp.Winapi/Browser/Handlers/CefSharpContextMenuHandler.cs
+++ b/src/Chromely.CefSharp.Winapi/Browser/Handlers/CefSharpContextMenuHandler.cs
@@ -35,9 +35,9 @@ namespace Chromely.CefSharp.Winapi.Browser.Handlers
         /// <summary>
         /// Initializes a new instance of the <see cref="CefSharpContextMenuHandler"/> class.
         /// </summary>
-        public CefSharpContextMenuHandler()
+        public CefSharpContextMenuHandler(bool debuggingMode)
         {
-            debugging = ChromelyConfiguration.Instance.DebuggingMode;
+            this.debugging = debuggingMode;
         }
 
         /// <summary>

--- a/src/Chromely.CefSharp.Winapi/Browser/Internals/ChromiumWebBrowserExtension.cs
+++ b/src/Chromely.CefSharp.Winapi/Browser/Internals/ChromiumWebBrowserExtension.cs
@@ -39,9 +39,9 @@ namespace Chromely.CefSharp.Winapi.Browser.Internals
                     var keyStr = enumKey.EnumToString();
                     try
                     {
-                        if (IoC.IsRegistered(service, keyStr))
+                        if (browser.Config.IoCContainer.IsRegistered(service, keyStr))
                         {
-                            instance = IoC.GetInstance(service, keyStr);
+                            instance = browser.Config.IoCContainer.GetInstance(service, keyStr);
                         }
                     }
                     catch (Exception exception)
@@ -144,9 +144,9 @@ namespace Chromely.CefSharp.Winapi.Browser.Internals
                     var keyStr = enumKey.EnumToString();
                     try
                     {
-                        if (IoC.IsRegistered(service, keyStr))
+                        if (browser.Config.IoCContainer.IsRegistered(service, keyStr))
                         {
-                            instance = IoC.GetInstance(service, keyStr);
+                            instance = browser.Config.IoCContainer.GetInstance(service, keyStr);
                         }
                     }
                     catch (Exception exception)
@@ -203,7 +203,7 @@ namespace Chromely.CefSharp.Winapi.Browser.Internals
                             }
                             else
                             {
-                                browser.MenuHandler = new CefSharpContextMenuHandler();
+                                browser.MenuHandler = new CefSharpContextMenuHandler(browser.Config.DebuggingMode);
                             }
 
                             break;
@@ -245,7 +245,7 @@ namespace Chromely.CefSharp.Winapi.Browser.Internals
                             {
                                 browser.DragHandler = dragHandler;
                             }
-                            else if (ChromelyConfiguration.Instance.HostFrameless)
+                            else if (browser.Config.HostFrameless)
                             {
                                 browser.DragHandler = new CefSharpDragHandler();
                             }

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
@@ -267,9 +267,9 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             {
                 if (!assembly.IsScanned)
                 {
-                    var scanner = new RouteScanner(assembly.Assembly);
+                    var scanner = new RouteScanner(assembly.Assembly, HostConfig.IoCContainer);
                     var currentRouteDictionary = scanner.Scan();
-                    ServiceRouteProvider.MergeRoutes(currentRouteDictionary);
+                    HostConfig.IoCContainer.MergeRoutes(currentRouteDictionary);
 
                     assembly.IsScanned = true;
                 }
@@ -378,7 +378,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// </summary>
         private void RunMessageLoop()
         {
-            NativeWindow.RunMessageLoop();
+            _mainView.RunMessageLoop();
         }
 
         /// <summary>
@@ -386,7 +386,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// </summary>
         private void QuitMessageLoop()
         {
-            NativeWindow.Exit();
+            _mainView.Exit();
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         private void RegisterSchemeHandlers()
         {
             // Register scheme handlers
-            var schemeHandlerObjs = IoC.GetAllInstances(typeof(ChromelySchemeHandler));
+            var schemeHandlerObjs = this.HostConfig.IoCContainer.GetAllInstances(typeof(ChromelySchemeHandler));
             if (schemeHandlerObjs != null)
             {
                 var schemeHandlers = schemeHandlerObjs.ToList();

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/NativeWindow.cs
@@ -64,11 +64,11 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// <summary>
         /// The run message loop.
         /// </summary>
-        public static void RunMessageLoop()
+        public virtual void RunMessageLoop()
         {
             while (User32Methods.GetMessage(out Message msg, IntPtr.Zero, 0, 0) != 0)
             {
-                if (ChromelyConfiguration.Instance.HostFrameless)
+                if (this._hostConfig.HostFrameless)
                 {
                     Cef.DoMessageLoopWork();
                 }
@@ -81,7 +81,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// <summary>
         /// The exit.
         /// </summary>
-        public static void Exit()
+        public virtual void Exit()
         {
             User32Methods.PostQuitMessage(0);
         }

--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/Window.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/Window.cs
@@ -36,9 +36,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         /// The host config.
         /// </summary>
         private readonly ChromelyConfiguration _hostConfig;
-        private IntPtr _browserWndProc;
-        private IntPtr _browserRenderWidgetHandle;
-        private IntPtr _browserRenderWidgetWndProc;
+
         private List<WndProcOverride> _wndProcOverrides = new List<WndProcOverride>();
 
         /// <summary>
@@ -57,7 +55,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
             : base(hostConfig)
         {
             _hostConfig = hostConfig;
-            Browser = new ChromiumWebBrowser(settings, _hostConfig.StartUrl);
+            Browser = new ChromiumWebBrowser(hostConfig, settings, _hostConfig.StartUrl);
             Browser.IsBrowserInitializedChanged += IsBrowserInitializedChanged;
 
             // Set handlers
@@ -243,7 +241,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
         private void RegisterJsHandlers()
         {
             // Register javascript handlers
-            var jsHandlerObjs = IoC.GetAllInstances(typeof(ChromelyJsHandler));
+            var jsHandlerObjs = this._hostConfig.IoCContainer.GetAllInstances(typeof(ChromelyJsHandler));
             if (jsHandlerObjs != null)
             {
                 var jsHandlers = jsHandlerObjs.ToList();

--- a/src/Chromely.CefSharp.Winapi/ChromelyConfigurationExtension.cs
+++ b/src/Chromely.CefSharp.Winapi/ChromelyConfigurationExtension.cs
@@ -82,7 +82,7 @@ namespace Chromely.CefSharp.Winapi
         {
             if (chromelyJsHandler != null)
             {
-                IoC.RegisterInstance(typeof(ChromelyJsHandler), chromelyJsHandler.Key, chromelyJsHandler);
+                configuration.IoCContainer.RegisterInstance(typeof(ChromelyJsHandler), chromelyJsHandler.Key, chromelyJsHandler);
             }
 
             return configuration;

--- a/src/Chromely.CefSharp.Winapi/FrameHandler.cs
+++ b/src/Chromely.CefSharp.Winapi/FrameHandler.cs
@@ -12,6 +12,7 @@ namespace Chromely.CefSharp.Winapi
     using global::CefSharp;
     using Chromely.CefSharp.Winapi.Browser.FrameHandlers;
     using Chromely.Core.Infrastructure;
+    using Chromely.Core;
 
     /// <summary>
     /// The frame handler extension.
@@ -21,29 +22,29 @@ namespace Chromely.CefSharp.Winapi
         /// <summary>
         /// The browser.
         /// </summary>
-        private static IBrowser mBrowser;
+        private static IBrowser _browser;
 
-        /// <summary>
-        /// Gets the browser.
-        /// </summary>
-        private static IBrowser Browser
-        {
-            get
-            {
-                if (mBrowser != null)
-                {
-                    return mBrowser;
-                }
+        ///// <summary>
+        ///// Gets the browser.
+        ///// </summary>
+        //private static IBrowser Browser
+        //{
+        //    get
+        //    {
+        //        if (mBrowser != null)
+        //        {
+        //            return mBrowser;
+        //        }
 
-                var cefSharpFrameHandler = IoC.GetInstance<CefSharpFrameHandler>(typeof(CefSharpFrameHandler).FullName);
-                if (cefSharpFrameHandler != null)
-                {
-                    mBrowser = cefSharpFrameHandler.Browser;
-                }
+        //        var cefSharpFrameHandler = IoC.GetInstance<CefSharpFrameHandler>(typeof(CefSharpFrameHandler).FullName);
+        //        if (cefSharpFrameHandler != null)
+        //        {
+        //            mBrowser = cefSharpFrameHandler.Browser;
+        //        }
 
-                return mBrowser;
-            }
-        }
+        //        return mBrowser;
+        //    }
+        //}
 
         /// <summary>
         /// The get main frame.
@@ -51,23 +52,24 @@ namespace Chromely.CefSharp.Winapi
         /// <returns>
         /// The <see cref="IFrame"/>.
         /// </returns>
-        public static IFrame GetMainFrame()
+        public static IFrame GetMainFrame(this IChromelyContainer container)
         {
-            return Browser?.MainFrame;
+            return container.GetBrowser()?.MainFrame;
         }
 
         /// <summary>
         /// The get frame.
         /// </summary>
+        /// <param name="container">Chromely container</param>
         /// <param name="name">
         /// The name.
         /// </param>
         /// <returns>
         /// The <see cref="IFrame"/>.
         /// </returns>
-        public static IFrame GetFrame(string name)
+        public static IFrame GetFrame(this IChromelyContainer container, string name)
         {
-            return Browser?.GetFrame(name);
+            return container.GetBrowser()?.GetFrame(name);
         }
 
         /// <summary>
@@ -76,9 +78,20 @@ namespace Chromely.CefSharp.Winapi
         /// <returns>
         /// The <see cref="IBrowser"/>.
         /// </returns>
-        public static IBrowser GetBrowser()
+        public static IBrowser GetBrowser(this IChromelyContainer container)
         {
-            return Browser;
+            if (_browser != null)
+            {
+                return _browser;
+            }
+
+            var cefSharpFrameHandler = container.GetInstance<CefSharpFrameHandler>(typeof(CefSharpFrameHandler).FullName);
+            if (cefSharpFrameHandler != null)
+            {
+                _browser = cefSharpFrameHandler.Browser;
+            }
+
+            return _browser;
         }
     }
 }

--- a/src/Chromely.Core/Infrastructure/IoC.cs
+++ b/src/Chromely.Core/Infrastructure/IoC.cs
@@ -16,6 +16,7 @@ namespace Chromely.Core.Infrastructure
     /// <summary>
     /// Global IOC container implementation.
     /// </summary>
+    [Obsolete("Use singletion IoC container on host configuration instead.")]
     public static class IoC
     {
         /// <summary>
@@ -228,6 +229,21 @@ namespace Chromely.Core.Infrastructure
         public static TService GetInstance<TService>(string key)
         {
             return (_container != null) ? _container.GetInstance<TService>(key) : default(TService);
+        }
+
+        /// <summary>
+        /// The get instance.
+        /// </summary>
+        /// <param name="container">The container</param>
+        /// <typeparam name="TService">
+        /// Service type.
+        /// </typeparam>
+        /// <returns>
+        /// Collection of TService objects to return.
+        /// </returns>
+        public static TService GetInstance<TService>(this IChromelyContainer container)
+        {
+            return container.GetInstance<TService>(typeof(TService).FullName);
         }
 
         /// <summary>

--- a/src/Chromely.Core/Infrastructure/Log.cs
+++ b/src/Chromely.Core/Infrastructure/Log.cs
@@ -37,7 +37,7 @@ namespace Chromely.Core.Infrastructure
         {
             get
             {
-                var logger = IoC.GetInstance(typeof(IChromelyLogger), typeof(Log).FullName);
+                var logger = IoC.Container.GetInstance(typeof(IChromelyLogger), typeof(Log).FullName);
                 if (logger is IChromelyLogger chromelyLogger)
                 {
                     return chromelyLogger;

--- a/src/Chromely.Core/Infrastructure/ServiceRouteProvider.cs
+++ b/src/Chromely.Core/Infrastructure/ServiceRouteProvider.cs
@@ -28,9 +28,10 @@ namespace Chromely.Core.Infrastructure
         /// <param name="route">
         /// The route.
         /// </param>
+        [Obsolete("Use IoC container extension method instead.")]
         public static void AddRoute(string key, Route route)
         {
-            IoC.RegisterInstance(typeof(Route), key, route);
+            IoC.Container.AddRoute(key, route);
         }
 
         /// <summary>
@@ -39,15 +40,10 @@ namespace Chromely.Core.Infrastructure
         /// <param name="newRouteDictionary">
         /// The new route dictionary.
         /// </param>
+        [Obsolete("Use IoC container extension method instead.")]
         public static void MergeRoutes(Dictionary<string, Route> newRouteDictionary)
         {
-            if (newRouteDictionary != null && newRouteDictionary.Any())
-            {
-                foreach (var item in newRouteDictionary)
-                {
-                    IoC.RegisterInstance(typeof(Route), item.Key, item.Value);
-                }
-            }
+            IoC.Container.MergeRoutes(newRouteDictionary);
         }
 
         /// <summary>
@@ -62,9 +58,64 @@ namespace Chromely.Core.Infrastructure
         /// <exception cref="Exception">
         /// Generic exception - Route Not found.
         /// </exception>
+        [Obsolete("Use IoC container extension method instead.")]
         public static Route GetRoute(RoutePath routePath)
         {
-            object routeObj = IoC.GetInstance(typeof(Route), routePath.Key);
+            return IoC.Container.GetRoute(routePath);
+        }
+
+
+        /****  Extensions methods ****/
+
+        /// <summary>
+        /// Adds route.
+        /// </summary>
+        /// <param name="container">Container on which register routes</param>
+        /// <param name="key">
+        /// The key.
+        /// </param>
+        /// <param name="route">
+        /// The route.
+        /// </param>
+        public static void AddRoute(this IChromelyContainer container, string key, Route route)
+        {
+            container.RegisterInstance(typeof(Route), key, route);
+        }
+
+        /// <summary>
+        /// Merge routes.
+        /// </summary>
+        /// <param name="container">Container on which register routes</param>
+        /// <param name="newRouteDictionary">
+        /// The new route dictionary.
+        /// </param>
+        public static void MergeRoutes(this IChromelyContainer container, Dictionary<string, Route> newRouteDictionary)
+        {
+            if (newRouteDictionary != null && newRouteDictionary.Any())
+            {
+                foreach (var item in newRouteDictionary)
+                {
+                    container.RegisterInstance(typeof(Route), item.Key, item.Value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The get route.
+        /// </summary>
+        /// <param name="container">IOC container</param>
+        /// <param name="routePath">
+        /// The route path.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Route"/>.
+        /// </returns>
+        /// <exception cref="Exception">
+        /// Generic exception - Route Not found.
+        /// </exception>
+        public static Route GetRoute(this IChromelyContainer container, RoutePath routePath)
+        {
+            object routeObj = container.GetInstance(typeof(Route), routePath.Key);
             if ((routeObj == null) || !(routeObj is Route))
             {
                 throw new Exception($"No route found for method:{routePath.Method} route path:{routePath.Path}.");

--- a/src/Chromely.Core/RestfulService/ChromelyControllerFactory.cs
+++ b/src/Chromely.Core/RestfulService/ChromelyControllerFactory.cs
@@ -24,13 +24,26 @@ namespace Chromely.Core.RestfulService
         /// </summary>
         /// <param name="type">Controller type to be created.</param>
         /// <returns>Instance reference or null if failed.</returns>
+        [Obsolete("Use IoC container extension method instead.")]
         public static ChromelyController CreateControllerInstance(Type type)
         {
-            var instance = CreateType(type);
+            return IoC.Container.CreateControllerInstance(type);
+        }
+
+        /// <summary>
+        /// Creates an instance of a chromely controller of given type.
+        /// Ctor dependency injection is done using the global IoC container.
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="type">Controller type to be created.</param>
+        /// <returns>Instance reference or null if failed.</returns>
+        public static ChromelyController CreateControllerInstance(this IChromelyContainer container, Type type)
+        {
+            var instance = CreateType(container, type);
             return instance as ChromelyController;
         }
 
-        private static object CreateType(Type type)
+        private static object CreateType(IChromelyContainer container, Type type)
         {
             object instance = null;
             foreach (var constructor in type.GetConstructors())
@@ -48,8 +61,8 @@ namespace Chromely.Core.RestfulService
                 {
                     var parameterInfo = parameters[ix];
 
-                    var iocInstance = IoC.GetAllInstances(parameterInfo.ParameterType).FirstOrDefault();
-                    var parameterInstance = iocInstance ?? CreateType(parameterInfo.ParameterType);
+                    var iocInstance = container.GetAllInstances(parameterInfo.ParameterType).FirstOrDefault();
+                    var parameterInstance = iocInstance ?? CreateType(container, parameterInfo.ParameterType);
 
                     paramValues[ix] = parameterInstance;
                 }

--- a/src/Chromely.Core/RestfulService/RouteScanner.cs
+++ b/src/Chromely.Core/RestfulService/RouteScanner.cs
@@ -26,6 +26,7 @@ namespace Chromely.Core.RestfulService
         /// Gets or sets the _assembly.
         /// </summary>
         private readonly Assembly _assembly;
+        private readonly IChromelyContainer _container;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RouteScanner"/> class.
@@ -33,9 +34,20 @@ namespace Chromely.Core.RestfulService
         /// <param name="assembly">
         /// The assembly.
         /// </param>
-        public RouteScanner(Assembly assembly)
+        [Obsolete("Use ioc overload with IoC container")]
+        public RouteScanner(Assembly assembly) : this(assembly, IoC.Container) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RouteScanner"/> class.
+        /// </summary>
+        /// <param name="assembly">
+        /// The assembly.
+        /// </param>
+        /// <param name="container">IoC container that used to resolve routs</param>
+        public RouteScanner(Assembly assembly, IChromelyContainer container)
         {
             _assembly = assembly;
+            _container = container;
         }
 
         /// <summary>
@@ -59,7 +71,7 @@ namespace Chromely.Core.RestfulService
                 {
                     if (type.BaseType == typeof(ChromelyController))
                     {
-                        var instance = ChromelyControllerFactory.CreateControllerInstance(type);
+                        var instance = this._container.CreateControllerInstance(type);
                         var currentRouteDictionary = instance.RouteDictionary;
 
                         // Merge with return route dictionary

--- a/src/Tests/Chromely.Core.Tests/Controller/DependencyInjectionTests.cs
+++ b/src/Tests/Chromely.Core.Tests/Controller/DependencyInjectionTests.cs
@@ -25,22 +25,23 @@ namespace Chromely.Core.Tests.Controller
             const string TestRoute = "/scannercontroller/get2";
             
             var test = new TestDependency();
-            IoC.RegisterInstance<ITestDependency>(nameof(ITestDependency), test);
+            var container = IoC.Container;
+            container.RegisterInstance<ITestDependency>(nameof(ITestDependency), test);
 
             var logger = new TestLogger(); 
-            IoC.RegisterInstance<IChromelyLogger>(nameof(IChromelyLogger), logger);
+            container.RegisterInstance<IChromelyLogger>(nameof(IChromelyLogger), logger);
 
-            var scanner = new RouteScanner(Assembly.GetExecutingAssembly());
+            var scanner = new RouteScanner(Assembly.GetExecutingAssembly(), container);
             var routes = scanner.Scan();
             foreach (var route in routes)
             {
-                ServiceRouteProvider.AddRoute(route.Key, route.Value);
+                container.AddRoute(route.Key, route.Value);
             }
             
             var request = new ChromelyRequest(new RoutePath(Method.GET, TestRoute), null, null);
 
             var routePath = new RoutePath(Method.GET, TestRoute);
-            var get2 = ServiceRouteProvider.GetRoute(routePath);
+            var get2 = container.GetRoute(routePath);
             var getResponse = get2.Invoke(request);
 
             Assert.Equal(TestDependency.TestDependencyResponse, getResponse.Data.ToString());

--- a/src/Tests/Chromely.Core.Tests/Controller/RouteScannerTest.cs
+++ b/src/Tests/Chromely.Core.Tests/Controller/RouteScannerTest.cs
@@ -42,9 +42,10 @@ namespace Chromely.Core.Tests.Controller
         [Fact]
         public void ScannerShouldFindAllRoutersInTestAssembly()
         {
+            var container = Infrastructure.IoC.Container;
             // Note that the current assembly scan will include this file
             // And all other routes defined in other files in the assembly
-            var scanner = new RouteScanner(Assembly.GetExecutingAssembly());
+            var scanner = new RouteScanner(Assembly.GetExecutingAssembly(), container);
             Assert.NotNull(scanner);
 
             var result = scanner.Scan();

--- a/src/Tests/Chromely.Core.Tests/RestfulService/ServiceRouteProviderTest.cs
+++ b/src/Tests/Chromely.Core.Tests/RestfulService/ServiceRouteProviderTest.cs
@@ -49,17 +49,19 @@ namespace Chromely.Core.Tests.RestfulService
         [Fact]
         public void RouteProviderTest()
         {
+            var container = IoC.Container;
+
             var routeDict = BaseTest();
             Assert.Equal(3, routeDict.Count);
 
             foreach (var item in routeDict)
             {
-                ServiceRouteProvider.AddRoute(item.Key, item.Value);
+                container.AddRoute(item.Key, item.Value);
             }
 
-            var getRoute1 = ServiceRouteProvider.GetRoute(new RoutePath(Method.GET, "/testcontroller/get1"));
-            var getRoute2 = ServiceRouteProvider.GetRoute(new RoutePath(Method.GET, "/testcontroller/get2"));
-            var postRoute = ServiceRouteProvider.GetRoute(new RoutePath(Method.POST, "/testcontroller/save"));
+            var getRoute1 = container.GetRoute(new RoutePath(Method.GET, "/testcontroller/get1"));
+            var getRoute2 = container.GetRoute(new RoutePath(Method.GET, "/testcontroller/get2"));
+            var postRoute = container.GetRoute(new RoutePath(Method.POST, "/testcontroller/save"));
             Assert.True((getRoute1 != null) || (getRoute2 != null) || (postRoute != null));
         }
 


### PR DESCRIPTION
Whats the point of this pull request? 

Currently Chromely uses dependency injection through static IoC container. This is bad. In fact, static IoC container is not dependency injection. It is Service Location, which is anti-pattern. 

This pull request tries to fix this, at least on some parts. Sure, there are many points, where it can be done better (For example in many places IChromelyContainer is still injected or used via ChromelyConfiguration), but this is just start. 

I'm looking forward to hear from maintainers of this repository suggestions, how can I improve this pull request. Thanks.

What have been done:
1. Removed all direct usages of IoC static class. All usages are replaced either with direct dependency injection, or resolved via ChromelyConfiguration.IoCContainer.
2. Eliminated ChromelyConfiguration Static instance usages - ChromelyConfiguration now injected directly.
3. Removed CefGlue/SharpBrowser static instance usages.
4. Removed NativeWindow static usages.
5. IoC, ChromelyConfiguration and ServiceRouteProvider static members are marked as obsolete.


Next steps.
1. Refactor RequestTaskRunner to not use ServiceRouteProvider static instance.
2. Refactor code, to not use ChromelyConfiguration.IoCContainer service location/registration. Use direct injection instead or create new services, where it is required.

