### PR TITLE
Fix Maximized/Fullscreen mode when Taskbar is not at the bottom

### DIFF
--- a/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefSharp.Winapi/BrowserWindow/HostBase.cs
@@ -373,8 +373,7 @@ namespace Chromely.CefSharp.Winapi.BrowserWindow
 
             _mainView = CreateMainView(_settings);
 
-            bool centerScreen = HostConfig.HostPlacement.CenterScreen;
-            if (centerScreen)
+            if (HostConfig.HostPlacement.CenterScreen && HostConfig.HostPlacement.State == WindowState.Normal)
             {
                 _mainView.CenterToScreen();
             }

--- a/src/Common/NativeWindowBase.cs
+++ b/src/Common/NativeWindowBase.cs
@@ -297,12 +297,8 @@ namespace Chromely.Common
         {
             if (nCode >= 0)
             {
-
-                var msg = (WM)wParam;
                 var hookInfo = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);
-
                 var key = (VirtualKey)hookInfo.vkCode;
-
 
 
                 bool alt = User32Methods.GetKeyState(VirtualKey.MENU).IsPressed;
@@ -448,8 +444,7 @@ namespace Chromely.Common
                         if (_hostConfig.HostPlacement.Frameless && _hostConfig.HostPlacement.FramelessOptions.IsResizable)
                         {
                             var result = User32Methods.DefWindowProc(hwnd, umsg, wParam, lParam);
-                            NativeMethods.NCCALCSIZE_PARAMS csp;
-                            csp = (NativeMethods.NCCALCSIZE_PARAMS)Marshal.PtrToStructure(
+                            var csp = (NativeMethods.NCCALCSIZE_PARAMS)Marshal.PtrToStructure(
                                 lParam,
                                 typeof(NativeMethods.NCCALCSIZE_PARAMS));
                             csp.rgrc[0].Top -= _hostConfig.HostPlacement.FramelessOptions.WhiteStripeHeight; // # remove top whitestripe border!
@@ -463,7 +458,7 @@ namespace Chromely.Common
                 case WM.MOVE:
                     {
                         OnMoving();
-                        return  IntPtr.Zero;
+                        return IntPtr.Zero;
                     }
 
                 case WM.SIZE:
@@ -498,8 +493,7 @@ namespace Chromely.Common
         {
             if (_hostConfig.UseHostCustomCreationStyle)
             {
-                var customCreationStyle = _hostConfig.HostCustomCreationStyle as WindowCreationStyle;
-                if (customCreationStyle != null)
+                if (_hostConfig.HostCustomCreationStyle is WindowCreationStyle customCreationStyle)
                 {
                     return GetWindowStyles(customCreationStyle, state);
                 }


### PR DESCRIPTION
Hi,

thanks for Chromely, it is really helpful. I ran into a small problem on environments where the taskbar is not pined to the bottom and WindowState is set to Maximized or Fullscreen. The automatic centering will push the window behind the taskbar which is not correct.

![max1](https://user-images.githubusercontent.com/65206/67626325-f51b0300-f849-11e9-8335-6a5974bc3479.PNG)

with the fix, the window bounds are aligned as expected. i think centering does not make any sense in that case

![max2](https://user-images.githubusercontent.com/65206/67626334-1e3b9380-f84a-11e9-8db0-6b9c10df6f2a.PNG)
