### PR TITLE
Add support of AJAX requests for front-end app #156

### DIFF
--- a/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
@@ -248,7 +248,7 @@ namespace Chromely.CefGlue.BrowserWindow
             RegisterMessageRouters();
             RegisterResourceHandlers();
             RegisterSchemeHandlers();
-            RegisterExternalSchemeHandlers();
+            RegisterAjaxSchemeHandlers();
 
             CefBinariesLoader.DeleteTempFiles(tempFiles);
 

--- a/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostBase.cs
@@ -248,6 +248,7 @@ namespace Chromely.CefGlue.BrowserWindow
             RegisterMessageRouters();
             RegisterResourceHandlers();
             RegisterSchemeHandlers();
+            RegisterExternalSchemeHandlers();
 
             CefBinariesLoader.DeleteTempFiles(tempFiles);
 

--- a/src/Chromely.CefGlue/BrowserWindow/HostServicesBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostServicesBase.cs
@@ -186,18 +186,18 @@ namespace Chromely.CefGlue.BrowserWindow
         }
 
         /// <summary>
-        /// The register external scheme handlers.
+        /// The register AJAX scheme handlers.
         /// </summary>
-        private void RegisterExternalSchemeHandlers()
+        private void RegisterAjaxSchemeHandlers()
         {
             if (!CefRuntime.CurrentlyOn(CefThreadId.UI))
             {
-                PostTask(CefThreadId.UI, RegisterExternalSchemeHandlers);
+                PostTask(CefThreadId.UI, RegisterAjaxSchemeHandlers);
                 return;
             }
 
-            // Register external scheme handlers
-            var schemeSchemes = _config?.UrlSchemes.GetAllExternalSchemes();
+            // Register AJAX scheme handlers
+            var schemeSchemes = _config?.UrlSchemes.GetAllAjaxSchemes();
             if (schemeSchemes != null && schemeSchemes.Any())
             {
                 foreach (var item in schemeSchemes)

--- a/src/Chromely.CefGlue/BrowserWindow/HostServicesBase.cs
+++ b/src/Chromely.CefGlue/BrowserWindow/HostServicesBase.cs
@@ -186,6 +186,43 @@ namespace Chromely.CefGlue.BrowserWindow
         }
 
         /// <summary>
+        /// The register external scheme handlers.
+        /// </summary>
+        private void RegisterExternalSchemeHandlers()
+        {
+            if (!CefRuntime.CurrentlyOn(CefThreadId.UI))
+            {
+                PostTask(CefThreadId.UI, RegisterExternalSchemeHandlers);
+                return;
+            }
+
+            // Register external scheme handlers
+            var schemeSchemes = _config?.UrlSchemes.GetAllExternalSchemes();
+            if (schemeSchemes != null && schemeSchemes.Any())
+            {
+                foreach (var item in schemeSchemes)
+                {
+                    bool isDefault = true;
+                    if (!string.IsNullOrWhiteSpace(item.Name))
+                    {
+                        var schemeObj = _container.GetInstance(typeof(IChromelySchemeHandlerFactory), item.Name);
+                        var schemeHandlerFactory = schemeObj as CefSchemeHandlerFactory;
+                        if (schemeHandlerFactory != null)
+                        {
+                            isDefault = false;
+                            CefRuntime.RegisterSchemeHandlerFactory(item.Scheme, item.Host, schemeHandlerFactory);
+                        }
+                    }
+
+                    if (isDefault)
+                    {
+                        CefRuntime.RegisterSchemeHandlerFactory(item.Scheme, item.Host, new ExternalRequestSchemeHandlerFactory());
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// The register message routers.
         /// </summary>
         private void RegisterMessageRouters()

--- a/src/Chromely.Core/Configuration/ConfigurationHandler.cs
+++ b/src/Chromely.Core/Configuration/ConfigurationHandler.cs
@@ -172,6 +172,7 @@ namespace Chromely.Core.Configuration
                     case UrlSchemeOption.COMMAND: return UrlSchemeType.Command;
                     case UrlSchemeOption.CUSTOM: return UrlSchemeType.Custom;
                     case UrlSchemeOption.EXTERNAL: return UrlSchemeType.External;
+                    case UrlSchemeOption.AJAX: return UrlSchemeType.Ajax;
                 }
 
                 return UrlSchemeType.None;

--- a/src/Chromely.Core/Helpers/ConfigKeys.cs
+++ b/src/Chromely.Core/Helpers/ConfigKeys.cs
@@ -23,6 +23,7 @@
         public const string COMMAND = nameof(COMMAND);
         public const string CUSTOM = nameof(CUSTOM);
         public const string EXTERNAL = nameof(EXTERNAL);
+        public const string AJAX = nameof(AJAX);
     }
 
     public static class DefaultSchemeName

--- a/src/Chromely.Core/Infrastructure/UrlScheme.cs
+++ b/src/Chromely.Core/Infrastructure/UrlScheme.cs
@@ -106,6 +106,11 @@ namespace Chromely.Core.Infrastructure
             return IsUrlOfSameScheme(url) && (UrlSchemeType == UrlSchemeType.Command);
         }
 
+        public bool IsUrlRegisteredAjax(string url)
+        {
+            return IsUrlOfSameScheme(url) && (UrlSchemeType == UrlSchemeType.Ajax);
+        }
+
         private bool IsValidUrl(string url)
         {
             if (BaseUrlStrict &&

--- a/src/Chromely.Core/Infrastructure/UrlSchemeCollectionExtension.cs
+++ b/src/Chromely.Core/Infrastructure/UrlSchemeCollectionExtension.cs
@@ -52,12 +52,12 @@ namespace Chromely.Core.Infrastructure
             return urlSchemes.Where(x => x.UrlSchemeType == UrlSchemeType.Custom);
         }
 
-        public static IEnumerable<UrlScheme> GetAllExternalSchemes(this List<UrlScheme> urlSchemes)
+        public static IEnumerable<UrlScheme> GetAllAjaxSchemes(this List<UrlScheme> urlSchemes)
         {
             if (urlSchemes == null || !urlSchemes.Any())
                 return new List<UrlScheme>();
 
-            return urlSchemes.Where(x => x.UrlSchemeType == UrlSchemeType.External);
+            return urlSchemes.Where(x => x.UrlSchemeType == UrlSchemeType.Ajax);
         }
 
         public static List<UrlScheme> GetSchemeList(this List<UrlScheme> urlSchemes, string url, UrlSchemeType type)

--- a/src/Chromely.Core/Infrastructure/UrlSchemeCollectionExtension.cs
+++ b/src/Chromely.Core/Infrastructure/UrlSchemeCollectionExtension.cs
@@ -52,6 +52,14 @@ namespace Chromely.Core.Infrastructure
             return urlSchemes.Where(x => x.UrlSchemeType == UrlSchemeType.Custom);
         }
 
+        public static IEnumerable<UrlScheme> GetAllExternalSchemes(this List<UrlScheme> urlSchemes)
+        {
+            if (urlSchemes == null || !urlSchemes.Any())
+                return new List<UrlScheme>();
+
+            return urlSchemes.Where(x => x.UrlSchemeType == UrlSchemeType.External);
+        }
+
         public static List<UrlScheme> GetSchemeList(this List<UrlScheme> urlSchemes, string url, UrlSchemeType type)
         {
             if (urlSchemes == null ||

--- a/src/Chromely.Core/Infrastructure/UrlSchemeType.cs
+++ b/src/Chromely.Core/Infrastructure/UrlSchemeType.cs
@@ -7,6 +7,7 @@
         AssemblyResource,
         Custom,
         Command,
-        External
+        External,
+        Ajax
     }
 }


### PR DESCRIPTION
~Added registration of external scheme handlers.~
Added AJAX scheme to be available out of the box.
Example configuration:
```json
{
    "name": "api",
    "baseUrl": "",
    "scheme": "https",
    "host": "jsonplaceholder.typicode.com",
    "urlSchemeType": "ajax",
    "baseUrlStrict": false
}
```