### PR TITLE
Event loop message suppressing fix for #153

### DIFF
--- a/src/Chromely/Native/WinAPI/FramelessWinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/FramelessWinAPIHost.cs
@@ -24,8 +24,6 @@ namespace Chromely.Native
         };
 
         private bool _maximized;
-        private bool _hasCapture;
-        private POINT _dragPoint;
 
         protected override Tuple<WindowStyles, WindowExStyles, ShowWindowCommand> GetWindowStyles(WindowState state)
         {
@@ -42,50 +40,6 @@ namespace Chromely.Native
             WM msg = (WM)message;
             switch (msg)
             {
-                case WM.LBUTTONDOWN:
-                    {
-                        if (!_maximized)
-                        {
-                            GetCursorPos(out var point);
-                            ScreenToClient(hWnd, ref point);
-
-                            // TODO: For some reason it only works when called twice in a row. Try to resolve it later.
-                            SetCapture(hWnd);
-                            SetCapture(hWnd);
-                            _dragPoint = point;
-                        }
-                        break;
-                    }
-                case WM.CAPTURECHANGED:
-                    {
-                        _hasCapture = lParam == hWnd;
-                        break;
-                    }
-                case WM.MOUSEMOVE:
-                    {
-                        if (_hasCapture)
-                        {
-                            var currentPoint = new System.Drawing.Point((int)lParam);
-                            var current = new Point(currentPoint.X, currentPoint.Y);
-                            ClientToScreen(hWnd, ref current);
-
-                            var position = new Point(current.X - _dragPoint.X, current.Y - _dragPoint.Y);
-                            SetWindowPos(hWnd, IntPtr.Zero, position.X, position.Y, 0, 0,
-                                SetWindowPosFlags.DoNotActivate
-                                | SetWindowPosFlags.IgnoreZOrder
-                                | SetWindowPosFlags.DoNotChangeOwnerZOrder
-                                | SetWindowPosFlags.IgnoreResize);
-                        }
-                        break;
-                    }
-                case WM.LBUTTONUP:
-                    {
-                        if (_hasCapture)
-                        {
-                            ReleaseCapture();
-                        }
-                        break;
-                    }
                 case WM.CREATE:
                     _handle = hWnd;
                     break;

--- a/src/Chromely/Native/WinAPI/WinNativeMethods.cs
+++ b/src/Chromely/Native/WinAPI/WinNativeMethods.cs
@@ -857,6 +857,31 @@ namespace Chromely.Native
             return Environment.Is64BitProcess ? GetWindowLongPtr64(hWnd, nIndex) : GetWindowLongPtr32(hWnd, nIndex);
         }
 
+        public enum ShowWindowCommands : int
+        {
+            Hide = 0,
+            Normal = 1,
+            Minimized = 2,
+            Maximized = 3,
+        }
+
+        [Serializable]
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WINDOWPLACEMENT
+        {
+            public int Length;
+            public int Flags;
+            public ShowWindowCommands ShowCmd;
+            public System.Drawing.Point PtMinPosition;
+            public System.Drawing.Point PtMaxPosition;
+            public System.Drawing.Rectangle RcNormalPosition;
+        }
+
+
+        [DllImport(User32DLL, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
         [DllImport(User32DLL)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EnumChildWindows(IntPtr hWnd, EnumWindowProc callback, IntPtr lParam);

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -13,7 +13,7 @@ namespace Chromely.Native
     {
         public delegate IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
         private readonly IChromelyConfiguration _config;
-        private readonly ForwardMesssageHandler[] _hitTestReplacers;
+        private readonly DragWindowHandler[] _dragWindowHandlers;
 
         public WindowMessageInterceptor(IChromelyConfiguration config, IntPtr browserHandle, IChromelyNativeHost nativeHost)
         {
@@ -21,9 +21,9 @@ namespace Chromely.Native
             var framelessOption = _config?.WindowOptions?.FramelessOption ?? new FramelessOption();
 
             var childHandles = GetAllChildHandles(browserHandle);
-            _hitTestReplacers = childHandles
+            _dragWindowHandlers = childHandles
                 .Concat(new[] { browserHandle })
-                .Select(h => new ForwardMesssageHandler(h, nativeHost, framelessOption, h == browserHandle))
+                .Select(h => new DragWindowHandler(h, nativeHost, framelessOption, h == browserHandle))
                 .ToArray();
         }
 
@@ -60,7 +60,7 @@ namespace Chromely.Native
             return true;
         }
 
-        private class ForwardMesssageHandler
+        private class DragWindowHandler
         {
             private readonly IntPtr _handle;
             private readonly IChromelyNativeHost _nativeHost;
@@ -71,7 +71,7 @@ namespace Chromely.Native
             private bool _hasCapture;
             private POINT _dragPoint;
 
-            public ForwardMesssageHandler(IntPtr handle, IChromelyNativeHost nativeHost, FramelessOption framelessOption, bool isHost)
+            public DragWindowHandler(IntPtr handle, IChromelyNativeHost nativeHost, FramelessOption framelessOption, bool isHost)
             {
                 _handle = handle;
                 _nativeHost = nativeHost;

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -2,6 +2,7 @@
 using Chromely.Core.Host;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using static Chromely.Native.WinNativeMethods;
@@ -67,6 +68,8 @@ namespace Chromely.Native
             private readonly IntPtr _originalWndProc;
             private readonly WndProc _wndProc;
             private readonly FramelessOption _framelessOption;
+            private bool _hasCapture;
+            private POINT _dragPoint;
 
             public ForwardMesssageHandler(IntPtr handle, IChromelyNativeHost nativeHost, FramelessOption framelessOption, bool isHost)
             {
@@ -82,48 +85,93 @@ namespace Chromely.Native
 
             private IntPtr WndProc(IntPtr hWnd, uint message, IntPtr wParam, IntPtr lParam)
             {
-                var isForwardedArea = IsForwardedArea();
-                if (isForwardedArea)
-                {
-                    SendMessage(_nativeHost.Handle, (int)message, wParam, lParam);
-                }
-
                 var msg = (WM)message;
+                var isDraggableArea = IsDraggableArea(msg, lParam);
+
                 switch (msg)
                 {
-                    case WM.NCHITTEST:
+                    case WM.LBUTTONDOWN:
+                    {
+                        if (!isDraggableArea)
                         {
-                            if (isForwardedArea && _isHost)
-                            {
-                                return (IntPtr)HitTestValue.HTNOWHERE;
-                            }
                             break;
                         }
-                    default:
+
+                        var maximized = IsWindowMaximized(_nativeHost.Handle);
+                        if (maximized)
                         {
-                            if (isForwardedArea)
-                            {
-                                return IntPtr.Zero;
-                            }
                             break;
                         }
+
+                        GetCursorPos(out var point);
+                        ScreenToClient(_nativeHost.Handle, ref point);
+                        _dragPoint = point;
+
+                        // TODO: For some reason it only works when called twice in a row. Try to resolve it later.
+                        SetCapture(hWnd);
+                        SetCapture(hWnd);
+                        return IntPtr.Zero;
+                    }
+                case WM.CAPTURECHANGED:
+                    {
+                        _hasCapture = lParam == hWnd;
+                        return IntPtr.Zero;
+                    }
+                case WM.MOUSEMOVE:
+                    {
+                        if (_hasCapture)
+                        {
+                            var currentPoint = new Point((int)lParam);
+                            var current = new Point(currentPoint.X, currentPoint.Y);
+                            ClientToScreen(_nativeHost.Handle, ref current);
+
+                            var position = new Point(current.X - _dragPoint.X, current.Y - _dragPoint.Y);
+                            SetWindowPos(_nativeHost.Handle, IntPtr.Zero, position.X, position.Y, 0, 0,
+                                SetWindowPosFlags.DoNotActivate
+                                | SetWindowPosFlags.IgnoreZOrder
+                                | SetWindowPosFlags.DoNotChangeOwnerZOrder
+                                | SetWindowPosFlags.IgnoreResize);
+                            return IntPtr.Zero;
+                        }
+                        break;
+                    }
+                case WM.LBUTTONUP:
+                    {
+                        if (_hasCapture)
+                        {
+                            ReleaseCapture();
+                        }
+                        break;
+                    }
                 }
 
                 return CallWindowProc(_originalWndProc, hWnd, message, wParam, lParam);
             }
 
-            // TODO: Enchance to configurable region.
-            private bool IsForwardedArea()
+            private bool IsDraggableArea(WM message, IntPtr lParam)
             {
-                GetCursorPos(out var point);
-                DpiScreenToClient(_nativeHost.Handle, ref point);
-                return _framelessOption.IsDraggable(_nativeHost, new System.Drawing.Point(point.X, point.Y));
+                if (message != WM.LBUTTONDOWN)
+                {
+                    return false;
+                }
+
+                var point = new Point((int)lParam);
+                AdjustPointDpi(_nativeHost.Handle, ref point);
+                return _framelessOption.IsDraggable(_nativeHost, point);
+            }
+
+            private bool IsWindowMaximized(IntPtr hWnd)
+            {
+                WINDOWPLACEMENT placement = new WINDOWPLACEMENT();
+                placement.Length = Marshal.SizeOf(placement);
+                GetWindowPlacement(hWnd, ref placement);
+                return placement.ShowCmd == ShowWindowCommands.Maximized;
             }
 
             /// <summary>
             /// Gets the correct point for the scaled window.
             /// </summary>
-            private void DpiScreenToClient(IntPtr hWnd, ref POINT point)
+            private void AdjustPointDpi(IntPtr hWnd, ref Point point)
             {
                 const int StandardDpi = 96;
                 float scale = 1;
@@ -138,7 +186,6 @@ namespace Chromely.Native
                     ReleaseDC(hWnd, hdc);
                 }
 
-                ScreenToClient(_nativeHost.Handle, ref point);
                 point.X = (int)(point.X / scale);
                 point.Y = (int)(point.Y / scale);
             }


### PR DESCRIPTION
Window message interceptors suppressing event loop messages too aggressive. It is not even possible to write something to the inputs, while mouse pointed to draggable area.

This fix filtering out only mouse events. Also moves responsibility of frameless window dragging feature to interceptors, to remove event propagation and handle the functional in-place.