### PR TITLE
Fixes to scaling issues under Windows, additional properties for FramelessOption

### DIFF
--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -3,27 +3,61 @@ using Chromely.Core.Host;
 
 namespace Chromely.Core.Configuration
 {
+    /// <summary> Options associated with the Frameless mode. </summary>
     public class FramelessOption
     {
+        public bool UseDefaultFramelessController { get; set; }
+        public bool UseWebkitAppRegions { get; set; }
+
+        /// <summary>
+        ///     Delegate Callback function to determine if the point is within the draggable area.
+        /// </summary>
+        /// <param name="nativeHost"> The native host. </param>
+        /// <param name="point">      The click point. </param>
+        /// <returns> True if the click point is within the draggable area. </returns>
         public delegate bool IsDraggableCallback(IChromelyNativeHost nativeHost, Point point);
 
+        /// <summary> Callback function to determine if the point is within the draggable area. </summary>
+        /// <value> True if the click point is within the draggable area. </value>
+        public IsDraggableCallback IsDraggable { get; set; }
+
+        /// <summary> The height of the drag zone, typically at the top of the window. </summary>
+        /// <value> The height of the drag zone. </value>
+        public int DragZoneHeight { get; set; }
+
+        /// <summary> The offset from the top of the frame to start the drag area. </summary>
+        /// <value> The offset from the top of the frame. </value>
+        public int DragZoneTopOffset { get; set; }
+
+        /// <summary> The offset from the left of the frame to start the drag area. </summary>
+        /// <value> The offset from the left of the frame. </value>
+        public int DragZoneLeftOffset { get; set; }
+
+        /// <summary> The offset from the right of the frame to start the drag area. </summary>
+        /// <value> The offset from the right of the frame. </value>
+        public int DragZoneRightOffset { get; set; }
+
+
+        /// <summary> Default constructor. </summary>
         public FramelessOption()
         {
             UseDefaultFramelessController = true;
             UseWebkitAppRegions = false;
+            DragZoneHeight = 32;
+            DragZoneTopOffset = 0;
+            DragZoneLeftOffset = 0;
+            DragZoneRightOffset = 140;
             IsDraggable = (nativeHost, point) =>
             {
-                const int DraggableHeight = 32;
-                const int NonDraggableRightOffsetWidth = 140;
-
-                var size = nativeHost.GetWindowClientSize();
+                var size = nativeHost.GetWindowClientSizeScaled();
                 var right = size.Width - point.X;
-                return point.Y <= DraggableHeight && right > NonDraggableRightOffsetWidth;
+
+                // Define a bounding box for the drag area
+                return point.Y <= (DragZoneHeight + DragZoneTopOffset) && 
+                       point.Y >= DragZoneTopOffset &&
+                       point.X >= DragZoneLeftOffset &&
+                       right > DragZoneRightOffset;
             };
         }
-
-        public bool UseDefaultFramelessController { get; set; }
-        public bool UseWebkitAppRegions { get; set; }
-        public IsDraggableCallback IsDraggable { get; set; }
     }
 }

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -47,15 +47,17 @@ namespace Chromely.Core.Configuration
             DragZoneTopOffset = 0;
             DragZoneLeftOffset = 0;
             DragZoneRightOffset = 140;
-            IsDraggable = (nativeHost, point) =>
-            {
-                var size = nativeHost.GetWindowClientSizeScaled();
-                var right = size.Width - point.X;
+            IsDraggable = (nativeHost, point) => {
+                var scalingfactor = nativeHost.GetWindowDpiScalingFactor();
+                var size = nativeHost.GetWindowClientSize();
+
+                var scaledpoint = new Point((int) (point.X * scalingfactor), (int) (point.Y * scalingfactor));
+                var right = size.Width - scaledpoint.X;
 
                 // Define a bounding box for the drag area
-                return point.Y <= (DragZoneHeight + DragZoneTopOffset) && 
-                       point.Y >= DragZoneTopOffset &&
-                       point.X >= DragZoneLeftOffset &&
+                return scaledpoint.Y <= (DragZoneHeight + DragZoneTopOffset) &&
+                       scaledpoint.Y >= DragZoneTopOffset &&
+                       scaledpoint.X >= DragZoneLeftOffset &&
                        right > DragZoneRightOffset;
             };
         }

--- a/src/Chromely.Core/Host/IChromelyNativeHost.cs
+++ b/src/Chromely.Core/Host/IChromelyNativeHost.cs
@@ -16,6 +16,7 @@ namespace Chromely.Core.Host
         IntPtr GetNativeHandle();
         void Run();
         Size GetWindowClientSize();
+        Size GetWindowClientSizeScaled();
         void ResizeBrowser(IntPtr browserWindow, int width, int height);
         void Exit();
         void MessageBox(string message, int type);

--- a/src/Chromely.Core/Host/IChromelyNativeHost.cs
+++ b/src/Chromely.Core/Host/IChromelyNativeHost.cs
@@ -16,7 +16,7 @@ namespace Chromely.Core.Host
         IntPtr GetNativeHandle();
         void Run();
         Size GetWindowClientSize();
-        Size GetWindowClientSizeScaled();
+        float GetWindowDpiScalingFactor();
         void ResizeBrowser(IntPtr browserWindow, int width, int height);
         void Exit();
         void MessageBox(string message, int type);

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -144,9 +144,8 @@ namespace Chromely.Native
             return new Size();
         }
 
-        public virtual Size GetWindowClientSizeScaled() 
-        {
-            return GetWindowClientSize();
+        public virtual float GetWindowDpiScalingFactor() {
+            return 1.0f;
         }
 
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -144,6 +144,10 @@ namespace Chromely.Native
             return new Size();
         }
 
+        public virtual Size GetWindowClientSizeScaled() {
+            return GetWindowClientSize();
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             try

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -144,7 +144,8 @@ namespace Chromely.Native
             return new Size();
         }
 
-        public virtual Size GetWindowClientSizeScaled() {
+        public virtual Size GetWindowClientSizeScaled() 
+        {
             return GetWindowClientSize();
         }
 

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -85,6 +85,10 @@ namespace Chromely.Native
             return new Size();
         }
 
+        public virtual Size GetWindowClientSizeScaled() {
+            return GetWindowClientSize();
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
         }

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -85,9 +85,8 @@ namespace Chromely.Native
             return new Size();
         }
 
-        public virtual Size GetWindowClientSizeScaled() 
-        {
-            return GetWindowClientSize();
+        public virtual float GetWindowDpiScalingFactor() {
+            return 1.0f;
         }
 
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -85,7 +85,8 @@ namespace Chromely.Native
             return new Size();
         }
 
-        public virtual Size GetWindowClientSizeScaled() {
+        public virtual Size GetWindowClientSizeScaled() 
+        {
             return GetWindowClientSize();
         }
 

--- a/src/Chromely/Native/WinAPI/WinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/WinAPIHost.cs
@@ -152,18 +152,14 @@ namespace Chromely.Native
             return GetClientSize();
         }
 
-        /// <summary> Gets the size of the window after scaling under windows. </summary>
-        /// <returns> The window client size after scaling. </returns>
-        public virtual Size GetWindowClientSizeScaled() 
-        {
-            var winsize = GetClientSize();
-
+        /// <summary>
+        ///     Under windows the x / y click events can be scaled based on the dpi / scaling setting.
+        /// </summary>
+        /// <returns> The window scaling factor. </returns>
+        public virtual float GetWindowDpiScalingFactor() {
             // The returned value is the dpi, dividing by 96f results in the scale
             var windowscale = GetDpiForWindow(_handle) / 96f;
-
-            winsize.Width = (int)(winsize.Width / windowscale);
-            winsize.Height = (int)(winsize.Height / windowscale);
-            return winsize;
+            return windowscale;
         }
 
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)

--- a/src/Chromely/Native/WinAPI/WinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/WinAPIHost.cs
@@ -152,6 +152,20 @@ namespace Chromely.Native
             return GetClientSize();
         }
 
+        /// <summary> Gets the size of the window after scaling under windows. </summary>
+        /// <returns> The window client size after scaling. </returns>
+        public virtual Size GetWindowClientSizeScaled() 
+        {
+            var winsize = GetClientSize();
+
+            // The returned value is the dpi, dividing by 96f results in the scale
+            var windowscale = GetDpiForWindow(_handle) / 96f;
+
+            winsize.Width = (int)(winsize.Width / windowscale);
+            winsize.Height = (int)(winsize.Height / windowscale);
+            return winsize;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             if (browserWindow != IntPtr.Zero)

--- a/src/Chromely/Native/WinAPI/WinNativeMethods.cs
+++ b/src/Chromely/Native/WinAPI/WinNativeMethods.cs
@@ -713,6 +713,9 @@ namespace Chromely.Native
         [DllImport(User32DLL, SetLastError = true)]
         public static extern IntPtr GetDC(IntPtr hWnd);
 
+        [DllImport(User32DLL, SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern uint GetDpiForWindow(IntPtr hwnd);
+
         public enum SystemMetrics
         {
             CXSCREEN = 0,


### PR DESCRIPTION
This is related to https://github.com/chromelyapps/Chromely/issues/174

Windows has an option to scale things for high resolution desktops
this can result in an incorrect width reading when calculating the right hand side of the drag area.
So I've fixed that and added some additional properties just to make defining the drag area more easy