### PR TITLE
Fixes to dragzone scaling, doubleclick support, multiple drag zones V2

### DIFF
--- a/src/Chromely.Core/Configuration/DragZoneConfiguration.cs
+++ b/src/Chromely.Core/Configuration/DragZoneConfiguration.cs
@@ -1,9 +1,11 @@
 ﻿using System.Drawing;
 
-namespace Chromely.Core.Configuration {
+namespace Chromely.Core.Configuration 
+{
 
     /// <summary> Represents a drag zone on the main window. </summary>
-    public class DragZoneConfiguration {
+    public class DragZoneConfiguration 
+    {
 
         /// <summary> The height of the drag zone, typically at the top of the window. </summary>
         /// <value> The height of the drag zone. </value>
@@ -21,8 +23,10 @@ namespace Chromely.Core.Configuration {
         /// <value> The offset from the right of the frame. </value>
         public int RightOffset { get; set; }
 
+
         /// <summary> Default constructor. </summary>
-        public DragZoneConfiguration() {
+        public DragZoneConfiguration() 
+        {
         }
 
         /// <summary> Constructor. </summary>
@@ -30,7 +34,8 @@ namespace Chromely.Core.Configuration {
         /// <param name="topoffset">   The offset from the top of the frame. </param>
         /// <param name="leftoffset">  The offset from the left of the frame. </param>
         /// <param name="rightoffset"> The offset from the right of the frame. </param>
-        public DragZoneConfiguration(int height, int topoffset, int leftoffset, int rightoffset) {
+        public DragZoneConfiguration(int height, int topoffset, int leftoffset, int rightoffset) 
+        {
             Height = height;
             TopOffset = topoffset;
             LeftOffset = leftoffset;
@@ -40,14 +45,21 @@ namespace Chromely.Core.Configuration {
         /// <summary> Determines if the point is in the zone. </summary>
         /// <param name="size">  The size of the area to calculate the offsets. </param>
         /// <param name="point"> The point. </param>
-        /// <returns> True if in the zone </returns>
-        public bool InZone(Size size, Point point) {
-            var rightoffset = size.Width - point.X;
+        /// <param name="scale"> The scale to use for dpi / desktop scale compensation. </param>
+        /// <returns> True if in the zone. </returns>
+        public bool InZone(Size size, Point point, float scale) 
+        {
+            var HeightScaled = Height * scale;
+            var TopOffsetScaled = TopOffset * scale;
+            var LeftOffsetScaled = LeftOffset * scale;
+            var RightOffsetScaled = RightOffset * scale;
+
+            var point_rightoffset = size.Width - point.X;
             // Define a bounding box for the drag area
-            return point.Y <= (Height + TopOffset) &&
-                   point.Y >= TopOffset &&
-                   point.X >= LeftOffset &&
-                   rightoffset > RightOffset;
+            return point.Y <= (HeightScaled + TopOffsetScaled) &&
+                   point.Y >= TopOffsetScaled &&
+                   point.X >= LeftOffsetScaled &&
+                   point_rightoffset > RightOffsetScaled;
         }
     }
 }

--- a/src/Chromely.Core/Configuration/DragZoneConfiguration.cs
+++ b/src/Chromely.Core/Configuration/DragZoneConfiguration.cs
@@ -1,0 +1,53 @@
+﻿using System.Drawing;
+
+namespace Chromely.Core.Configuration {
+
+    /// <summary> Represents a drag zone on the main window. </summary>
+    public class DragZoneConfiguration {
+
+        /// <summary> The height of the drag zone, typically at the top of the window. </summary>
+        /// <value> The height of the drag zone. </value>
+        public int Height { get; set; }
+
+        /// <summary> The offset from the top of the frame to start the drag area. </summary>
+        /// <value> The offset from the top of the frame. </value>
+        public int TopOffset { get; set; }
+
+        /// <summary> The offset from the left of the frame to start the drag area. </summary>
+        /// <value> The offset from the left of the frame. </value>
+        public int LeftOffset { get; set; }
+
+        /// <summary> The offset from the right of the frame to start the drag area. </summary>
+        /// <value> The offset from the right of the frame. </value>
+        public int RightOffset { get; set; }
+
+        /// <summary> Default constructor. </summary>
+        public DragZoneConfiguration() {
+        }
+
+        /// <summary> Constructor. </summary>
+        /// <param name="height">      The height of the drag zone. </param>
+        /// <param name="topoffset">   The offset from the top of the frame. </param>
+        /// <param name="leftoffset">  The offset from the left of the frame. </param>
+        /// <param name="rightoffset"> The offset from the right of the frame. </param>
+        public DragZoneConfiguration(int height, int topoffset, int leftoffset, int rightoffset) {
+            Height = height;
+            TopOffset = topoffset;
+            LeftOffset = leftoffset;
+            RightOffset = rightoffset;
+        }
+
+        /// <summary> Determines if the point is in the zone. </summary>
+        /// <param name="size">  The size of the area to calculate the offsets. </param>
+        /// <param name="point"> The point. </param>
+        /// <returns> True if in the zone </returns>
+        public bool InZone(Size size, Point point) {
+            var rightoffset = size.Width - point.X;
+            // Define a bounding box for the drag area
+            return point.Y <= (Height + TopOffset) &&
+                   point.Y >= TopOffset &&
+                   point.X >= LeftOffset &&
+                   rightoffset > RightOffset;
+        }
+    }
+}

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Drawing;
 using Chromely.Core.Host;
 
-namespace Chromely.Core.Configuration {
+namespace Chromely.Core.Configuration 
+{
+
     /// <summary> Options associated with the Frameless mode. </summary>
-    public class FramelessOption {
+    public class FramelessOption 
+    {
         public bool UseDefaultFramelessController { get; set; }
         public bool UseWebkitAppRegions { get; set; }
 
@@ -18,7 +21,8 @@ namespace Chromely.Core.Configuration {
         public List<DragZoneConfiguration> DragZones { get; set; }
 
         /// <summary> Default constructor. </summary>
-        public FramelessOption() {
+        public FramelessOption() 
+        {
             UseDefaultFramelessController = true;
             UseWebkitAppRegions = false;
             DragZones = new List<DragZoneConfiguration>();
@@ -32,11 +36,14 @@ namespace Chromely.Core.Configuration {
         /// <param name="nativeHost"> The Chromely native host interface. </param>
         /// <param name="point">      The click point. </param>
         /// <returns> True if in the drag region, false if not. </returns>
-        public bool IsDraggableCallbackFunc(IChromelyNativeHost nativeHost, Point point) {
+        public bool IsDraggableCallbackFunc(IChromelyNativeHost nativeHost, Point point) 
+        {
             var size = nativeHost.GetWindowClientSize();
+            var scale = nativeHost.GetWindowDpiScale();
+
             var in_zone = false;
             foreach (var zone in DragZones) {
-                if (zone.InZone(size, point))
+                if (zone.InZone(size, point, scale))
                     in_zone = true;
             }
             return in_zone;

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -57,11 +57,14 @@ namespace Chromely.Core.Configuration
         /// <summary> Doubleclick callback function. </summary>
         /// <param name="nativeHost"> The Chromely native host interface. </param>
         public void DblClickCallbackFunc(IChromelyNativeHost nativeHost) {
-
-            // TODO as a default this should probably toggle the maximise / restore state of the window
-            // For now we leave this to the user as we lack a platform independent way of doing this
-
+            // Toggle between normal (restore) and maximized
+            var maximised = nativeHost.GetWindowIsMaximized();
+            if (maximised) {
+                nativeHost.SetWindowState(WindowState.Normal);
+            }
+            else {
+                nativeHost.SetWindowState(WindowState.Maximize);
+            }
         }
-
     }
 }

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -1,29 +1,45 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
 using Chromely.Core.Host;
 
-namespace Chromely.Core.Configuration
-{
-    public class FramelessOption
-    {
-        public delegate bool IsDraggableCallback(IChromelyNativeHost nativeHost, Point point);
-
-        public FramelessOption()
-        {
-            UseDefaultFramelessController = true;
-            UseWebkitAppRegions = false;
-            IsDraggable = (nativeHost, point) =>
-            {
-                const int DraggableHeight = 32;
-                const int NonDraggableRightOffsetWidth = 140;
-
-                var size = nativeHost.GetWindowClientSize();
-                var right = size.Width - point.X;
-                return point.Y <= DraggableHeight && right > NonDraggableRightOffsetWidth;
-            };
-        }
-
+namespace Chromely.Core.Configuration {
+    /// <summary> Options associated with the Frameless mode. </summary>
+    public class FramelessOption {
         public bool UseDefaultFramelessController { get; set; }
         public bool UseWebkitAppRegions { get; set; }
-        public IsDraggableCallback IsDraggable { get; set; }
+
+        /// <summary> Callback function to determine if the point is within the draggable area. </summary>
+        /// <value> True if the click point is within the draggable area. </value>
+        public Func<IChromelyNativeHost, Point, bool> IsDraggable { get; set; }
+
+        /// <summary> List of draggable areas. </summary>
+        /// <value> The drag zones. </value>
+        public List<DragZoneConfiguration> DragZones { get; set; }
+
+        /// <summary> Default constructor. </summary>
+        public FramelessOption() {
+            UseDefaultFramelessController = true;
+            UseWebkitAppRegions = false;
+            DragZones = new List<DragZoneConfiguration>();
+            DragZones.Add(new DragZoneConfiguration(32,0,0,140));
+            IsDraggable = IsDraggableCallbackFunc;
+        }
+
+        /// <summary>
+        ///     Default callback function to determine if we're located within the drag region.
+        /// </summary>
+        /// <param name="nativeHost"> The Chromely native host interface. </param>
+        /// <param name="point">      The click point. </param>
+        /// <returns> True if in the drag region, false if not. </returns>
+        public bool IsDraggableCallbackFunc(IChromelyNativeHost nativeHost, Point point) {
+            var size = nativeHost.GetWindowClientSize();
+            var in_zone = false;
+            foreach (var zone in DragZones) {
+                if (zone.InZone(size, point))
+                    in_zone = true;
+            }
+            return in_zone;
+        }
     }
 }

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -16,6 +16,10 @@ namespace Chromely.Core.Configuration
         /// <value> True if the click point is within the draggable area. </value>
         public Func<IChromelyNativeHost, Point, bool> IsDraggable { get; set; }
 
+        /// <summary> Callback function on double click events from the drag region. </summary>
+        /// <value> The double click callback. </value>
+        public Action<IChromelyNativeHost> DblClick { get; set; }
+
         /// <summary> List of draggable areas. </summary>
         /// <value> The drag zones. </value>
         public List<DragZoneConfiguration> DragZones { get; set; }
@@ -28,6 +32,7 @@ namespace Chromely.Core.Configuration
             DragZones = new List<DragZoneConfiguration>();
             DragZones.Add(new DragZoneConfiguration(32,0,0,140));
             IsDraggable = IsDraggableCallbackFunc;
+            DblClick = DblClickCallbackFunc;
         }
 
         /// <summary>
@@ -48,5 +53,15 @@ namespace Chromely.Core.Configuration
             }
             return in_zone;
         }
+
+        /// <summary> Doubleclick callback function. </summary>
+        /// <param name="nativeHost"> The Chromely native host interface. </param>
+        public void DblClickCallbackFunc(IChromelyNativeHost nativeHost) {
+
+            // TODO as a default this should probably toggle the maximise / restore state of the window
+            // For now we leave this to the user as we lack a platform independent way of doing this
+
+        }
+
     }
 }

--- a/src/Chromely.Core/Configuration/FramelessOption.cs
+++ b/src/Chromely.Core/Configuration/FramelessOption.cs
@@ -58,8 +58,8 @@ namespace Chromely.Core.Configuration
         /// <param name="nativeHost"> The Chromely native host interface. </param>
         public void DblClickCallbackFunc(IChromelyNativeHost nativeHost) {
             // Toggle between normal (restore) and maximized
-            var maximised = nativeHost.GetWindowIsMaximized();
-            if (maximised) {
+            var state = nativeHost.GetWindowState();
+            if (state == WindowState.Maximize) {
                 nativeHost.SetWindowState(WindowState.Normal);
             }
             else {

--- a/src/Chromely.Core/Host/IChromelyNativeHost.cs
+++ b/src/Chromely.Core/Host/IChromelyNativeHost.cs
@@ -16,6 +16,7 @@ namespace Chromely.Core.Host
         IntPtr GetNativeHandle();
         void Run();
         Size GetWindowClientSize();
+        float GetWindowDpiScale();
         void ResizeBrowser(IntPtr browserWindow, int width, int height);
         void Exit();
         void MessageBox(string message, int type);

--- a/src/Chromely.Core/Host/IChromelyNativeHost.cs
+++ b/src/Chromely.Core/Host/IChromelyNativeHost.cs
@@ -21,9 +21,9 @@ namespace Chromely.Core.Host
         void Exit();
         void MessageBox(string message, int type);
 
-        /// <summary> Determines if the window is maximized. </summary>
-        /// <returns> True if maximized. </returns>
-        bool GetWindowIsMaximized();
+        /// <summary> Gets the current window state Maximised / Normal / Minimised etc. </summary>
+        /// <returns> The window state. </returns>
+        WindowState GetWindowState();
 
         /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
         /// <param name="state"> The state to set. </param>

--- a/src/Chromely.Core/Host/IChromelyNativeHost.cs
+++ b/src/Chromely.Core/Host/IChromelyNativeHost.cs
@@ -20,5 +20,14 @@ namespace Chromely.Core.Host
         void ResizeBrowser(IntPtr browserWindow, int width, int height);
         void Exit();
         void MessageBox(string message, int type);
+
+        /// <summary> Determines if the window is maximized. </summary>
+        /// <returns> True if maximized. </returns>
+        bool GetWindowIsMaximized();
+
+        /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
+        /// <param name="state"> The state to set. </param>
+        /// <returns> True if it succeeds, false if it fails. </returns>
+        bool SetWindowState(WindowState state);
     }
 }

--- a/src/Chromely.Core/Host/WindowState.cs
+++ b/src/Chromely.Core/Host/WindowState.cs
@@ -3,6 +3,7 @@
     public enum WindowState
     {
         Normal,
+        Minimize,
         Maximize,
         Fullscreen
     }

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -144,6 +144,10 @@ namespace Chromely.Native
             return new Size();
         }
 
+        public virtual float GetWindowDpiScale() {
+            return 1.0f;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             try

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -148,6 +148,21 @@ namespace Chromely.Native
             return 1.0f;
         }
 
+        /// <summary> Determines if the window is maximised. </summary>
+        /// <returns> True if maximised. </returns>
+        public virtual bool GetWindowIsMaximized() {
+            // TODO required for frameless linux / gtk3 mode
+            return false;
+        }
+
+        /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
+        /// <param name="state"> The state to set. </param>
+        /// <returns> True if it succeeds, false if it fails. </returns>
+        public bool SetWindowState(WindowState state) {
+            // TODO required for frameless linux / gtk3 mode
+            return false;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             try

--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -148,11 +148,11 @@ namespace Chromely.Native
             return 1.0f;
         }
 
-        /// <summary> Determines if the window is maximised. </summary>
-        /// <returns> True if maximised. </returns>
-        public virtual bool GetWindowIsMaximized() {
+        /// <summary> Gets the current window state Maximised / Normal / Minimised etc. </summary>
+        /// <returns> The window state. </returns>
+        public virtual WindowState GetWindowState() {
             // TODO required for frameless linux / gtk3 mode
-            return false;
+            return WindowState.Normal;
         }
 
         /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -85,6 +85,10 @@ namespace Chromely.Native
             return new Size();
         }
 
+        public virtual float GetWindowDpiScale() {
+            return 1.0f;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
         }

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -89,11 +89,11 @@ namespace Chromely.Native
             return 1.0f;
         }
 
-        /// <summary> Determines if the window is maximised. </summary>
-        /// <returns> True if maximised. </returns>
-        public virtual bool GetWindowIsMaximized() {
+        /// <summary> Gets the current window state Maximised / Normal / Minimised etc. </summary>
+        /// <returns> The window state. </returns>
+        public virtual WindowState GetWindowState() {
             // TODO required for frameless Maccocoa mode
-            return false;
+            return WindowState.Normal;
         }
 
         /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>

--- a/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
+++ b/src/Chromely/Native/MacCocoa/MacCocoaHost.cs
@@ -89,6 +89,21 @@ namespace Chromely.Native
             return 1.0f;
         }
 
+        /// <summary> Determines if the window is maximised. </summary>
+        /// <returns> True if maximised. </returns>
+        public virtual bool GetWindowIsMaximized() {
+            // TODO required for frameless Maccocoa mode
+            return false;
+        }
+
+        /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
+        /// <param name="state"> The state to set. </param>
+        /// <returns> True if it succeeds, false if it fails. </returns>
+        public bool SetWindowState(WindowState state) {
+            // TODO required for frameless Maccocoa mode
+            return false;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
         }

--- a/src/Chromely/Native/WinAPI/WinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/WinAPIHost.cs
@@ -167,14 +167,22 @@ namespace Chromely.Native
             return scale;
         }
 
-        /// <summary> Determines if the window is maximised. </summary>
-        /// <returns> True if maximised. </returns>
-        public virtual bool GetWindowIsMaximized() {
+        public virtual WindowState GetWindowState() {
             var placement = new WINDOWPLACEMENT();
             placement.Length = Marshal.SizeOf(placement);
             GetWindowPlacement(_handle, ref placement);
-            return placement.ShowCmd == ShowWindowCommands.Maximized;
+            switch (placement.ShowCmd) {
+                case ShowWindowCommands.Maximized:
+                    return WindowState.Maximize;
+                case ShowWindowCommands.Minimized:
+                    return WindowState.Minimize;
+                case ShowWindowCommands.Normal:
+                    return WindowState.Normal;
+            }
+            // If unknown
+            return WindowState.Normal;
         }
+
 
         /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
         /// <param name="state"> The state to set. </param>

--- a/src/Chromely/Native/WinAPI/WinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/WinAPIHost.cs
@@ -167,6 +167,38 @@ namespace Chromely.Native
             return scale;
         }
 
+        /// <summary> Determines if the window is maximised. </summary>
+        /// <returns> True if maximised. </returns>
+        public virtual bool GetWindowIsMaximized() {
+            var placement = new WINDOWPLACEMENT();
+            placement.Length = Marshal.SizeOf(placement);
+            GetWindowPlacement(_handle, ref placement);
+            return placement.ShowCmd == ShowWindowCommands.Maximized;
+        }
+
+        /// <summary> Sets window state. Maximise / Minimize / Restore. </summary>
+        /// <param name="state"> The state to set. </param>
+        /// <returns> True if it succeeds, false if it fails. </returns>
+        public virtual bool SetWindowState(WindowState state) {
+            switch (state)
+            {
+                case WindowState.Normal:
+                    // Restore the window
+                    return ShowWindow(_handle, ShowWindowCommand.SW_RESTORE);
+                case WindowState.Minimize:
+                    // Minimize the window
+                    return ShowWindow(_handle, ShowWindowCommand.SW_SHOWMINIMIZED);
+                case WindowState.Maximize:
+                    // Maximize the window
+                    return ShowWindow(_handle, ShowWindowCommand.SW_SHOWMAXIMIZED);
+
+                    // TODO full screen support
+                    // try moving the fullscreen code from CreateWindow / kiosk mode
+                    // into its own function
+            }
+            return false;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             if (browserWindow != IntPtr.Zero)

--- a/src/Chromely/Native/WinAPI/WinAPIHost.cs
+++ b/src/Chromely/Native/WinAPI/WinAPIHost.cs
@@ -152,6 +152,21 @@ namespace Chromely.Native
             return GetClientSize();
         }
 
+        public virtual float GetWindowDpiScale()
+        {
+            const int StandardDpi = 96;
+            float scale = 1;
+            var hdc = GetDC(_handle);
+            try {
+                var dpi = GetDeviceCaps(hdc, (int)DeviceCap.LOGPIXELSY);
+                scale = (float)dpi / StandardDpi;
+            }
+            finally {
+                ReleaseDC(_handle, hdc);
+            }
+            return scale;
+        }
+
         public virtual void ResizeBrowser(IntPtr browserWindow, int width, int height)
         {
             if (browserWindow != IntPtr.Zero)

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -143,14 +143,21 @@ namespace Chromely.Native
                         }
                         break;
                     }
+                case WM.LBUTTONDBLCLK:
+                    {
+                        if (!isDraggableArea) {
+                            break;
+                        }
+                        _framelessOption.DblClick(_nativeHost);
+                        break;
+                    }
                 }
-
                 return CallWindowProc(_originalWndProc, hWnd, message, wParam, lParam);
             }
 
             private bool IsDraggableArea(WM message, IntPtr lParam)
             {
-                if (message != WM.LBUTTONDOWN)
+                if (message != WM.LBUTTONDOWN && message != WM.LBUTTONDBLCLK)
                 {
                     return false;
                 }

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -97,7 +97,7 @@ namespace Chromely.Native
                             break;
                         }
 
-                        var maximized = IsWindowMaximized(_nativeHost.Handle);
+                        var maximized = _nativeHost.GetWindowIsMaximized();
                         if (maximized)
                         {
                             break;
@@ -164,14 +164,6 @@ namespace Chromely.Native
 
                 var point = new Point((int)lParam);
                 return _framelessOption.IsDraggable(_nativeHost, point);
-            }
-
-            private bool IsWindowMaximized(IntPtr hWnd)
-            {
-                WINDOWPLACEMENT placement = new WINDOWPLACEMENT();
-                placement.Length = Marshal.SizeOf(placement);
-                GetWindowPlacement(hWnd, ref placement);
-                return placement.ShowCmd == ShowWindowCommands.Maximized;
             }
         }
     }

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -156,7 +156,6 @@ namespace Chromely.Native
                 }
 
                 var point = new Point((int)lParam);
-                AdjustPointDpi(_nativeHost.Handle, ref point);
                 return _framelessOption.IsDraggable(_nativeHost, point);
             }
 
@@ -166,28 +165,6 @@ namespace Chromely.Native
                 placement.Length = Marshal.SizeOf(placement);
                 GetWindowPlacement(hWnd, ref placement);
                 return placement.ShowCmd == ShowWindowCommands.Maximized;
-            }
-
-            /// <summary>
-            /// Gets the correct point for the scaled window.
-            /// </summary>
-            private void AdjustPointDpi(IntPtr hWnd, ref Point point)
-            {
-                const int StandardDpi = 96;
-                float scale = 1;
-                var hdc = GetDC(hWnd);
-                try
-                {
-                    var dpi = GetDeviceCaps(hdc, (int)DeviceCap.LOGPIXELSY);
-                    scale = (float)dpi / StandardDpi;
-                }
-                finally
-                {
-                    ReleaseDC(hWnd, hdc);
-                }
-
-                point.X = (int)(point.X / scale);
-                point.Y = (int)(point.Y / scale);
             }
         }
     }

--- a/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
+++ b/src/Chromely/Native/WinAPI/WindowMessageInterceptor.cs
@@ -97,8 +97,8 @@ namespace Chromely.Native
                             break;
                         }
 
-                        var maximized = _nativeHost.GetWindowIsMaximized();
-                        if (maximized)
+                        var state = _nativeHost.GetWindowState();
+                        if (state == WindowState.Maximize)
                         {
                             break;
                         }


### PR DESCRIPTION
I think I've got it figured now, originaly the click point was being scaled
but what needs to be scaled is the offsets or markers as to the edge of the drag zone instead
as the buttons will shrink or grow in size based on the dpi settings
I've also added support for multiple drag zones

I think in the case of https://github.com/chromelyapps/Chromely.Legacy/blob/master/src/Chromely.Core/Host/FramelessDragRegion.cs#L50
It's legacy code that I think is calculating the size of the drag area based on windows controls or some kind of native method

However I think the more typical use case for frameless is to use the controls within the UI framework
which will be different sizes based on the css or the UI in use (such as Bootstrap / Foundation / Quasar / Vuetify etc)
So I think the best approach is to just to give a sane default and let the end user customise it

## Double click Drag zone

There's now support for a double click event handler on the drag zone under FramelessOption
ideally this would restore / maximise the window when triggered as a default
but I don't think we have a OS independent way of doing that at the moment via IChromelyNativeHost, so I just leave it up to the end user to override / implement

## Testing

I've tried this under Windows 10 with multiple dpi settings and with EnableHighDpiSupport disabled and enabled and under a few other windows os's such as Win7, WinServer 2012, WinServer 2016
It all seems fine

I've been using this to test

  * https://github.com/Hecatron/Hecatron.Scraps/tree/master/Chromely.Examples/Chromely.Quasar1