### PR TITLE
A fix for Issue #187

### DIFF
--- a/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxGtk3Host.cs
@@ -43,6 +43,8 @@ namespace Chromely.Native
 
         public LinuxGtk3Host()
         {
+            gdk_set_allowed_backends("x11");
+
             _isInitialized = false;
             _handle = IntPtr.Zero;
             _xid = IntPtr.Zero;

--- a/src/Chromely/Native/LinuxGtk3/LinuxNativeMethods.cs
+++ b/src/Chromely/Native/LinuxGtk3/LinuxNativeMethods.cs
@@ -6,6 +6,9 @@ namespace Chromely.Native
 {
     public partial class LinuxNativeMethods
     {
+        [DllImport(Library.GdkLib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gdk_set_allowed_backends(string backend);
+
         [DllImport(Library.GtkLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void gtk_init(int argc, string[] argv);
 


### PR DESCRIPTION
I discovered that GTK tries to use Wayland to render the application window under GNOME, which was (for a to me unknown reason, since GTK is supposed to support running applications on the wayland backend) not possible. The added lines force GTK to use the x11 backend to render the application, which enables chromely to run on the standard gnome desktop environment.

This was tested using Fedora 31, however, it would be nice if someone could test the changes using another distro (e.g Ubuntu) aswell.
