### PR TITLE
Improved AppBuilder.EnsureIsDerivedType(Type baseType, Type derivedType) check

### DIFF
--- a/src/Chromely.Core/AppBuilder.cs
+++ b/src/Chromely.Core/AppBuilder.cs
@@ -141,14 +141,19 @@ namespace Chromely.Core
 
         private void EnsureIsDerivedType(Type baseType, Type derivedType)
         {
-            if (derivedType.FullName.Equals(baseType.FullName, StringComparison.OrdinalIgnoreCase))
+            if (baseType == derivedType)
             {
-                throw new Exception($"Type {derivedType.Name} must implement {baseType.Name}.");
+                throw new Exception($"Cannot specify the base type {baseType.Name} itself as generic type parameter.");
             }
 
             if (!baseType.IsAssignableFrom(derivedType))
             {
                 throw new Exception($"Type {derivedType.Name} must implement {baseType.Name}.");
+            }
+
+            if (derivedType.IsAbstract || derivedType.IsInterface)
+            {
+                throw new Exception($"Type {derivedType.Name} cannot be an interface or abstract class.");
             }
         }
     }


### PR DESCRIPTION
The current implementation of `AppBuilder.EnsureIsDerivedType(Type baseType, Type derivedType)` implementation is problematic, as it does not reliably and correctly determine wheter a given `derivedType` is indeed derived from `baseType`. Now, since it is a private method serving a rather limited purpose, the chance for the this problematic behavior to occur will entirely rely on how exactly other AppBuilder methods utilize `EnsureIsDerivedType`.

Yet, the method can be both somewhat simplified and made more robust/correct at the same time.

The current implementation checks if the full name of `derivedType` is equal to the full name of `baseType` in an attempt to check whether the the `derivedType` and `baseType` arguments represent the same type. Not only is it not neccessary to do string comparisons of the (full) type names here, but doing a case-insensitive string comparison is also fundamentally wrong since names in .NET (including type names) are case-sensitive. The whole string comparison thing can be replaced by a straightforward direct type comparison (`if (baseType == derivedType) ...`)

While at it, i also added an addtional check to the `EnsureIsDerivedType` method which generates a meaningful exception in case the derivedType represents an interface or abstract class (while deriving from/implementing the baseType).

(Purely from a technical point of view, none of the methods currently invoking EnsureIsDerivedType need to invoke EnsureIsDerivedType other than for the more specific exception messages generated by that method. The generic type parameter constraints on the methods invoking EnsureIsDerivedType ensure that `baseType` is always assignable from `derivedType`, and `Activator.CreateInstance` itself will throw if `derivedType` is an interface or abstract class type.)
