### PR TITLE
fix: allow netstandard2.0

### DIFF
--- a/src/Chromely.Core/Chromely.Core.csproj
+++ b/src/Chromely.Core/Chromely.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <ProductVersion>5.1.0.0-pre01</ProductVersion>
     <AssemblyVersion>5.1.0.0</AssemblyVersion>
@@ -28,13 +28,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.1\Chromely.Core.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\Chromely.Core.xml</DocumentationFile>
     <WarningsAsErrors>NU1605</WarningsAsErrors>
     <NoWarn>1701;1702; NU5125</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.1\Chromely.Core.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\Chromely.Core.xml</DocumentationFile>
     <NoWarn>1701;1702; NU5125;7035</NoWarn>
   </PropertyGroup>
 

--- a/src/Chromely/Chromely.csproj
+++ b/src/Chromely/Chromely.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <ProductVersion>5.1.83.0-pre01</ProductVersion>
     <AssemblyVersion>5.1.83.0</AssemblyVersion>
@@ -25,15 +25,16 @@
     <Configurations>Debug;Release;ReleaseLinux;DebugLinux</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.1\Chromely.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\Chromely.xml</DocumentationFile>
     <NoWarn>1701;1702; NU5125;7035</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.1\Chromely.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\$(TargetFramework)\Chromely.xml</DocumentationFile>
     <NoWarn>1701;1702; NU5125;7035</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Allows use of latest c# features while downleveling to netstandard2.0

ref #239