### PR TITLE
Changes for custom hosts

### DIFF
--- a/src/Chromely/Browser/CefBrowserApp.cs
+++ b/src/Chromely/Browser/CefBrowserApp.cs
@@ -10,7 +10,7 @@ using Xilium.CefGlue;
 
 namespace Chromely.Browser
 {
-    internal class CefBrowserApp : CefApp
+    public class CefBrowserApp : CefApp
     {
         private readonly CefRenderProcessHandler _renderProcessHandler;
         private readonly CefBrowserProcessHandler _browserProcessHandler;

--- a/src/Chromely/Browser/CefBrowserClient.Handlers.cs
+++ b/src/Chromely/Browser/CefBrowserClient.Handlers.cs
@@ -6,7 +6,7 @@ using Xilium.CefGlue;
 
 namespace Chromely.Browser
 {
-    internal partial class CefBrowserClient 
+    public partial class CefBrowserClient 
     {
         private void SetHandlers(ChromelyHandlersResolver handlersResolver)
         {

--- a/src/Chromely/Browser/CefBrowserClient.cs
+++ b/src/Chromely/Browser/CefBrowserClient.cs
@@ -10,7 +10,7 @@ namespace Chromely.Browser
     /// <summary>
     /// The CEF brwoser client.
     /// </summary>
-    internal partial class CefBrowserClient : CefClient
+    public partial class CefBrowserClient : CefClient
     {
         private CefMessageRouterBrowserSide _browserMessageRouter;
 

--- a/src/Chromely/Browser/ChromiumBrowser.cs
+++ b/src/Chromely/Browser/ChromiumBrowser.cs
@@ -20,7 +20,7 @@ namespace Chromely.Browser
         protected IntPtr _browserWindowHandle;
 
         private CefBrowserSettings _settings;
-        private CefBrowserClient _client;
+        private CefClient _client;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChromiumBrowser"/> class.
@@ -143,11 +143,15 @@ namespace Chromely.Browser
             }
         }
 
+        protected virtual CefClient CreateClient() {
+            return new CefBrowserClient(_browserMessageRouter, _handlersResolver);
+        }
+
         internal void CreateBrowser(IntPtr hostHandle, IntPtr winXID)
         {
             if (_client == null)
             {
-                _client = new CefBrowserClient(_browserMessageRouter, _handlersResolver);
+                _client = CreateClient();
             }
             if (_settings == null)
             {

--- a/src/Chromely/ChromelyBasicApp.cs
+++ b/src/Chromely/ChromelyBasicApp.cs
@@ -15,7 +15,7 @@ namespace Chromely
     /// </summary>
     public class ChromelyBasicApp: ChromelyAppBase
     {
-        public sealed override void ConfigureCoreServices(ServiceCollection services)
+        public override void ConfigureCoreServices(ServiceCollection services)
         {
             base.ConfigureCoreServices(services);
 

--- a/src/Chromely/ChromelyBasicApp.cs
+++ b/src/Chromely/ChromelyBasicApp.cs
@@ -15,7 +15,7 @@ namespace Chromely
     /// </summary>
     public class ChromelyBasicApp: ChromelyAppBase
     {
-        public override void ConfigureCoreServices(ServiceCollection services)
+        public sealed override void ConfigureCoreServices(ServiceCollection services)
         {
             base.ConfigureCoreServices(services);
 

--- a/src/Chromely/NativeHosts/WinHost/ChromelyWinHost.cs
+++ b/src/Chromely/NativeHosts/WinHost/ChromelyWinHost.cs
@@ -5,7 +5,7 @@ using Chromely.Core.Host;
 
 namespace Chromely.NativeHost
 {
-    internal class ChromelyWinHost : NativeHostBase
+    public class ChromelyWinHost : NativeHostBase
     {
         public ChromelyWinHost(IKeyboadHookHandler keyboadHandler = null): base(keyboadHandler)
         {

--- a/src/Chromely/NativeHosts/WinHost/WinBase/Fullscreen.cs
+++ b/src/Chromely/NativeHosts/WinHost/WinBase/Fullscreen.cs
@@ -9,7 +9,7 @@ using static Chromely.Interop.User32;
 
 namespace Chromely.NativeHost
 {
-    abstract partial class NativeHostBase
+    public abstract partial class NativeHostBase
     {
         public virtual void ToggleFullscreen(IntPtr hWnd)
         {

--- a/src/Chromely/WindowController.Run.cs
+++ b/src/Chromely/WindowController.Run.cs
@@ -47,6 +47,10 @@ namespace Chromely
             NativeHost_Quit();
         }
 
+        protected virtual CefApp CreateApp() {
+            return new CefBrowserApp(_config, _requestSchemeProvider, _handlersResolver);
+        }
+
         protected int RunInternal(string[] args)
         {
             MacHostRuntime.LoadNativeHostFile(_config);
@@ -106,7 +110,7 @@ namespace Chromely
             ResolveHandlers();
 
             var mainArgs = new CefMainArgs(argv);
-            CefApp app = new CefBrowserApp(_config, _requestSchemeProvider, _handlersResolver);
+            CefApp app = CreateApp();
 
             if (ClientAppUtils.ExecuteProcess(_config.Platform, argv))
             {


### PR DESCRIPTION
Hello

This is the initial set of changes required to override `CefClient` and `CefApp` while keeping the AppBuilder structure.

It's not perfect, but it's a start.
Here's an example: https://github.com/uxmal/reko-chromely/tree/037635c093c7163e9543f0e85884326a8c5df36b/src/BrowserHost

Do you have a suggestion on how to avoid having to do this?: https://github.com/uxmal/reko-chromely/blob/037635c093c7163e9543f0e85884326a8c5df36b/src/BrowserHost/RekoApp.cs#L25-L26
