### PR TITLE
- Removed JsonSerializerOptions from IChromelySerializerUtil

### DIFF
--- a/src/Chromely.Core/IChromelySerializerUtil.cs
+++ b/src/Chromely.Core/IChromelySerializerUtil.cs
@@ -2,13 +2,11 @@
 // Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
 using System.Collections.Generic;
-using System.Text.Json;
 
 namespace Chromely.Core
 {
     public interface IChromelySerializerUtil
     {
-        JsonSerializerOptions SerializerOptions { get; set; }
         string ObjectToJson(object value);
         string EnsureResponseDataIsJson(object value);
         IDictionary<string, object> JsonToArray(string json);


### PR DESCRIPTION
In `DefaultSerializerUtil`, there is one property `SerializerOptions`.

- This make Chromely heavily depends on `System.Text.Json`.
- Only `DefaultSerializerUtil` use this property, why should we define `SerializerOptions` in `IChromelySerializerUtil`.
- By removing `SerializerOption` from `IChromelySerializerUtil`, more JSON framework can be integrated with **Chromely**, such as [NewtonSoft.Json](https://github.com/JamesNK/Newtonsoft.Json) as the implementation below:

<details>
  <summary>NewtonSoftSerializerUtil.cs</summary>
  
 ```
public class NewtonSoftSerializerUtil : IChromelySerializerUtil
    {
        #region Properties

        // ReSharper disable once InconsistentNaming
        protected readonly JsonSerializerSettings _jsonSerializerSettings;

        // ReSharper disable once InconsistentNaming
        protected readonly ILogger _logger;

        #endregion

        #region Constructor

        public NewtonSoftSerializerUtil(IServiceProvider serviceProvider)
        {
            _jsonSerializerSettings = serviceProvider.GetService<JsonSerializerSettings>();
            _logger = serviceProvider.GetService<ILogger>();

        }

        #endregion

        #region Methods

        #endregion}

        public string ObjectToJson(object value)
        {
            if (value == null)
                return null;

            try
            {
                if (value.IsOfType<string>() && value.ToString().IsValidJson())
                    return value.ToString();

                return JsonConvert.SerializeObject(value, _jsonSerializerSettings);
            }
            catch (Exception exception)
            {
                _logger?.LogInformation(exception.Message);
            }

            return value.ToString();
        }

        public string EnsureResponseDataIsJson(object value)
        {
            if (value == null)
            {
                var returnNullData = new { Data = value };
                return JsonConvert.SerializeObject(returnNullData, _jsonSerializerSettings);
            }

            try
            {
                if (!value.IsOfType<string>())
                    return JsonConvert.SerializeObject(value, _jsonSerializerSettings);

                if (value.ToString().IsValidJson())
                    return value.ToString();

                var returnData = new { Data = value };
                return JsonConvert.SerializeObject(value, _jsonSerializerSettings);
            }
            catch (Exception)
            {
                // Swallow
            }

            return value.ToString();
        }

        public IDictionary<string, object> JsonToArray(string json)
        {
            try
            {
                if (string.IsNullOrWhiteSpace(json))
                    return null;

                return JsonConvert.DeserializeObject<IDictionary<string, object>>(json, _jsonSerializerSettings);
            }
            catch (Exception exception)
            {
                //Logger.Instance.Log.LogError(exception, exception.Message);
            }

            return null;
        }

        public IDictionary<string, string> ObjectToDictionary(object value)
        {
            try
            {
                if (value == null) return null;

                if (value.IsOfType<string>() && value.ToString().IsValidJson())
                {
                    return JsonConvert.DeserializeObject<IDictionary<string, string>>(value.ToString(), _jsonSerializerSettings);
                }

                var dict = value as IDictionary<string, string>;
                if (dict != null)
                {
                    var dictRes = new Dictionary<string, string>();
                    foreach (var item in dict)
                    {
                        dictRes.Add(item.Key, item.Value);
                    }
                    return dictRes;
                }

                dict = value as IDictionary<string, string>;
                if (dict != null)
                {
                    return dict;
                }
            }
            catch (Exception)
            {
                // ignored
            }

            return null;
        }
    }
```
</details>

<details>
  <summary>MyApp.cs</summary>
  
 ```
public class MyApp : ChromelyBasicApp
{
	#region Properties

	private readonly IConfiguration _configuration;

	#endregion

	#region Constructor

	public MyApp(IConfiguration configuration)
	{
		_configuration = configuration;
	}

	#endregion

	#region Methods

	/// <summary>
	///     <inheritdoc />
	/// </summary>
	/// <param name="services"></param>
	public override void ConfigureServices(IServiceCollection services)
	{
		var jsonSerializerSettings = new JsonSerializerSettings();
		jsonSerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
		services.AddSingleton(jsonSerializerSettings);
		
		
		// New serializer registration
		services.AddSingleton<IChromelySerializerUtil, NewtonSoftSerializerUtil>();

		base.ConfigureServices(services);
	}

	/// <summary>
	///     <inheritdoc />
	/// </summary>
	/// <param name="serviceProvider"></param>
	public override void Initialize(IServiceProvider serviceProvider)
	{
		base.Initialize(serviceProvider);
	}

	#endregion
}
```
</details>

