### PR TITLE
Restore lost DPI scaling fix for draggable regions feature

### DIFF
--- a/src/Chromely/Browser/Handlers/DefaultDragHandler.cs
+++ b/src/Chromely/Browser/Handlers/DefaultDragHandler.cs
@@ -71,6 +71,10 @@ namespace Chromely.Browser
                 {
                     framelessOption.IsDraggable = (nativeHost, point) =>
                     {
+                        var scale = nativeHost.GetWindowDpiScale();
+                        point.X = (int)(point.X / scale);
+                        point.Y = (int)(point.Y / scale);
+
                         var hitNoDrag = regions.Any(r => !r.Draggable && ContainsPoint(r, point));
                         if (hitNoDrag)
                         {


### PR DESCRIPTION
We had this fix in #153, then it was lost somehow. Probably during drag handler implementation.