### PR TITLE
Added helper classes for Port / URL discovery and cleanup of the host thread

### DIFF
--- a/src/Chromely/Browser/ClientUrlHelper.cs
+++ b/src/Chromely/Browser/ClientUrlHelper.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.NetworkInformation;
+
+namespace Chromely.Browser {
+
+    /// <summary> Helper class for finding an available TCP Port. </summary>
+    public class ClientUrlHelper {
+
+        /// <summary> The start range. </summary>
+        private static int PortStartRange { get; set; } = 5001;
+
+        /// <summary> The end range. </summary>
+        private static int PortEndRange { get; set; } = 6000;
+
+        /// <summary> Gets an available tcp port that is not in use. </summary>
+        /// <returns> The available port. </returns>
+        public static int GetAvailablePort() {
+            var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var endpoints = ipGlobalProperties.GetActiveTcpListeners();
+            for (int i = PortStartRange; i < PortEndRange; i++) {
+                if (IsPortAvailable(i, endpoints)) {
+                    return i;
+                }
+            }
+            // Free port not found
+            return -1;
+        }
+
+        /// <summary> Queries if a port is available. </summary>
+        /// <param name="port"> The port number. </param>
+        /// <returns> True if the port is available, false if not. </returns>
+        public static bool IsPortAvailable(int port) {
+            var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var endpoints = ipGlobalProperties.GetActiveTcpListeners();
+            return IsPortAvailable(port, endpoints);
+        }
+
+        /// <summary> Queries if a port is available. </summary>
+        /// <param name="port">      The port number. </param>
+        /// <param name="endpoints"> The list of tcp endpoints. </param>
+        /// <returns> True if the port is available, false if not. </returns>
+        public static bool IsPortAvailable(int port, IPEndPoint[] endpoints) {
+            foreach (IPEndPoint endpoint in endpoints) {
+                if (endpoint.Port == port) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary> Get a local https / http url based on a free port. </summary>
+        /// <returns> The local HTTPS / HTTP url. </returns>
+        public static List<string> GetLocalHttpUrls(int port, bool https = true) {
+            if (port == -1) {
+                throw new IOException("No port found available within the range");
+            }
+            var appurls = new List<string>();
+            if (https) {
+                appurls.Add($"https://127.0.0.1:{port}");
+            }
+            else {
+                appurls.Add($"http://127.0.0.1:{port}");
+            }
+            return appurls;
+        }
+    }
+}

--- a/src/Chromely/Browser/HostTaskRunner.cs
+++ b/src/Chromely/Browser/HostTaskRunner.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chromely.Browser {
+
+    /// <summary>
+    ///     A Helper class for launching Chromely under a seperate thread / task, this helps with
+    ///     cleanup on exit.
+    /// </summary>
+    public class HostTaskRunner {
+
+        private Task BlazorTask;
+        private CancellationTokenSource BlazorTaskTokenSource;
+        private Action HostBuilderAction;
+        private int Port;
+
+        /// <summary> Constructor. </summary>
+        /// <param name="action"> The action to run for creating the hostbuilder. </param>
+        /// <param name="port">   The port to monitor. </param>
+        public HostTaskRunner(Action action, int port) {
+            HostBuilderAction = action;
+            Port = port;
+        }
+
+        /// <summary> start the kestrel server in a background thread. </summary>
+        public void Launch() {
+            BlazorTaskTokenSource = new CancellationTokenSource();
+
+            // start the kestrel server in a background thread.
+            BlazorTask = new Task(HostBuilderAction, BlazorTaskTokenSource.Token, TaskCreationOptions.LongRunning);
+            BlazorTask.Start();
+
+            // wait untill its up
+            while (ClientUrlHelper.IsPortAvailable(Port)) {
+                Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        ///     Clean up kestrel process if not taken down by OS. This can occur when the app is closed
+        ///     from WindowController (frameless).
+        /// </summary>
+        /// <param name="sender"> Source of the event. </param>
+        /// <param name="e">      Event information. </param>
+        public void ProcessExit(object sender, EventArgs e) {
+            Task.Run(() => {
+                WaitHandle.WaitAny(new[] { BlazorTaskTokenSource?.Token.WaitHandle });
+            });
+            BlazorTaskTokenSource?.Cancel();
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I've added a couple of helper class's which might come in useful to simplify some of the demo / template apps

  * ClientUrlHelper - helper class to find a free port / the application url to use
  * HostTaskRunner - helper class to run the host process in a separate thread / cleanup on application close

I've got an example of the code in use here
https://github.com/Hecatron-Forks/MudBlazor.Templates/tree/master/MudBlazor.Template.DefaultBlazor/Desktop/DefaultBlazor.Desktop.Chromely

I'm not sure if the names of the class's / namespace is ok
but I did notice that different demos had different ways of setting things up such as this one
https://github.com/chromelyapps/demo-projects/blob/master/blazor/ServerAppDemo/ServerAppUtil.cs

This one uses a Memory mapped file to pass the port number to child processes
But from what I can gather that isn't required (or at least it isn't with the latest version of Chromely I've tested with)
and MemoryMappedFile isn't cross platform
But the method for searching for a free network port was better than the one I was using myself so I nabbed that bit of code.

Anyway I figured it might just be an idea to put some of the common code shared between the demos into a couple of class's in the library
to help set things up / reduce code duplication
