### PR TITLE
Adding MainBundlePath as configurable through custom settings.

### DIFF
--- a/src/Chromely.Core/Infrastructure/ConfigKeys.cs
+++ b/src/Chromely.Core/Infrastructure/ConfigKeys.cs
@@ -85,6 +85,7 @@ namespace Chromely.Core.Infrastructure
         public const string ACCEPTLANGUAGELIST = nameof(ACCEPTLANGUAGELIST);
         public const string FOCUSEDNODECHANGEDENABLED = nameof(FOCUSEDNODECHANGEDENABLED);
         public const string FRAMEWORKDIRPATH = nameof(FRAMEWORKDIRPATH);
+        public const string MAINBUNDLEPATH = nameof(MAINBUNDLEPATH);
     }
 
     public static class ResourceStatus

--- a/src/Chromely/Browser/CefSettingsExtension.cs
+++ b/src/Chromely/Browser/CefSettingsExtension.cs
@@ -196,7 +196,10 @@ namespace Chromely.Browser
                     case CefSettingKeys.FRAMEWORKDIRPATH:
                         cefSettings.FrameworkDirPath = setting.Value;
                         break;
-
+                    // MacOS Only
+                    case CefSettingKeys.MAINBUNDLEPATH:
+                        cefSettings.MainBundlePath = setting.Value;
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
When configuring MainBundlePath, it is not necessary to use the special folder for CEF sub-processes on MacOS. This lets you configure it via Chromely's custom settings.