### PR TITLE
Fix CA1304 warning.

### DIFF
--- a/src/Chromely.Core/Defaults/DefaultActionRequestHandler.cs
+++ b/src/Chromely.Core/Defaults/DefaultActionRequestHandler.cs
@@ -42,7 +42,7 @@ public class DefaultActionRequestHandler : IChromelyRequestHandler
             return _chromelyErrorHandler.HandleRouteNotFound(requestId, routePath);
         }
 
-        if (routePath.ToLower().Equals("/info"))
+        if (routePath.Equals("/info", StringComparison.OrdinalIgnoreCase))
         {
             return _chromelyInfo.GetInfo(requestId);
         }
@@ -64,7 +64,7 @@ public class DefaultActionRequestHandler : IChromelyRequestHandler
             return _chromelyErrorHandler.HandleRouteNotFound(requestId, routePath);
         }
 
-        if (routePath.ToLower().Equals("/info"))
+        if (routePath.Equals("/info", StringComparison.OrdinalIgnoreCase))
         {
             return _chromelyInfo.GetInfo(requestId);
         }

--- a/src/Chromely.Core/Infrastructure/ChromelyRuntime.cs
+++ b/src/Chromely.Core/Infrastructure/ChromelyRuntime.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 Chromely Projects. All rights reserved.
+// Copyright Â© 2017 Chromely Projects. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
 namespace Chromely.Core.Infrastructure;
@@ -59,7 +59,7 @@ public static class ChromelyRuntime
         try
         {
             var osName = Environment.OSVersion.VersionString;
-            if (osName.ToLower().Contains("darwin")) return true;
+            if (osName.ToLowerInvariant().Contains("darwin")) return true;
             if (File.Exists(@"/System/Library/CoreServices/SystemVersion.plist")) return true;
         }
         catch { }

--- a/src/Chromely.Core/Infrastructure/Helpers.cs
+++ b/src/Chromely.Core/Infrastructure/Helpers.cs
@@ -462,8 +462,8 @@ public static class Helpers
     public static bool IsValidJson(this string strInput)
     {
         strInput = strInput.Trim();
-        if ((strInput.StartsWith("{") && strInput.EndsWith("}")) || //For object
-            (strInput.StartsWith("[") && strInput.EndsWith("]"))) //For array
+        if ((strInput.StartsWith("{", StringComparison.Ordinal) && strInput.EndsWith("}", StringComparison.Ordinal)) || //For object
+            (strInput.StartsWith("[", StringComparison.Ordinal) && strInput.EndsWith("]", StringComparison.Ordinal))) //For array
         {
             return true;
         }

--- a/src/Chromely.Core/Network/MimeMapper.cs
+++ b/src/Chromely.Core/Network/MimeMapper.cs
@@ -2292,7 +2292,7 @@ public static class MimeMapper
             throw new ArgumentNullException(nameof(extension));
         }
 
-        if (!extension.StartsWith("."))
+        if (!extension.StartsWith(".", StringComparison.Ordinal))
         {
             extension = "." + extension;
         }

--- a/src/Chromely.Core/Network/RouteKey.cs
+++ b/src/Chromely.Core/Network/RouteKey.cs
@@ -9,13 +9,13 @@ public static class RouteKey
     {
         url = url?.Trim().TrimStart('/');
         var routeKey = $"action_{url}".Replace("/", "_").Replace("\\", "_");
-        return routeKey.ToLower();
+        return routeKey.ToLowerInvariant();
     }
 
     public static string CreateCommandKey(string? url)
     {
         url = url?.Trim().TrimStart('/');
         var routeKey = $"commmand_{url}".Replace("/", "_").Replace("\\", "_");
-        return routeKey.ToLower();
+        return routeKey.ToLowerInvariant();
     }
 }

--- a/src/Chromely.Core/Network/Routes/PathAndQuery.cs
+++ b/src/Chromely.Core/Network/Routes/PathAndQuery.cs
@@ -37,7 +37,7 @@ public class PathAndQuery
 
         try
         {
-            if (!requestUrl.Trim().StartsWith("/"))
+            if (!requestUrl.Trim().StartsWith("/", StringComparison.Ordinal))
             {
                 requestUrl = $"/{requestUrl.Trim()}";
             }

--- a/src/Chromely.Core/Network/Routes/RouteKeys.cs
+++ b/src/Chromely.Core/Network/Routes/RouteKeys.cs
@@ -8,7 +8,7 @@ public static class RouteKeys
     public static string CreateSchemeKey(string scheme, string host, string folder)
     {
         folder = string.IsNullOrWhiteSpace(folder) ? "none" : folder;
-        var keyString = $"{scheme}_{host}_{folder}".ToLower();
+        var keyString = $"{scheme}_{host}_{folder}".ToLowerInvariant();
         return CreateMD5Hash(keyString);
     }
 
@@ -50,6 +50,6 @@ public static class RouteKeys
             sb.Append(hashBytes[i].ToString("X2"));
         }
 
-        return sb.ToString().ToLower();
+        return sb.ToString().ToLowerInvariant();
     }
 }

--- a/src/Chromely.Core/Network/UrlScheme.cs
+++ b/src/Chromely.Core/Network/UrlScheme.cs
@@ -7,7 +7,7 @@ namespace Chromely.Core.Network;
 /// The Chromely url scheme.
 /// </summary>
 /// <remarks>
-/// The UrlScheme allows developers to configure how a scheme is handled. 
+/// The UrlScheme allows developers to configure how a scheme is handled.
 /// This is dictated mostly be url scheme type as defined in <see cref="Network.UrlSchemeType"/>.
 /// </remarks>
 public class UrlScheme
@@ -162,7 +162,7 @@ public class UrlScheme
     /// <summary>
     /// Gets or sets a value indicating whether url must be relative to base.
     /// Only valid for external url.
-    /// If base is http://a.com/me/you then 
+    /// If base is http://a.com/me/you then
     /// http://a.com/me/you/they is valid but
     /// http://a.com/me/they is not  valid
     /// </summary>
@@ -191,7 +191,7 @@ public class UrlScheme
             return false;
         }
 
-        return scheme.ToLower() switch
+        return scheme.ToLowerInvariant() switch
         {
             "http" or "https" or "file" or "ftp" or "about" or "data" => true,
             _ => false,
@@ -220,8 +220,8 @@ public class UrlScheme
             return false;
         }
 
-        if (Scheme.ToLower().Equals(uri.Scheme) &&
-            Host.ToLower().Equals(uri.Host))
+        if (Scheme.Equals(uri.Scheme, StringComparison.OrdinalIgnoreCase) &&
+            Host.Equals(uri.Host, StringComparison.OrdinalIgnoreCase))
         {
             return IsValidUrl(url);
         }

--- a/src/Chromely/Browser/CefBrowserApp.cs
+++ b/src/Chromely/Browser/CefBrowserApp.cs
@@ -55,8 +55,8 @@ internal class CefBrowserApp : CefApp
                     {
                         // add if not already added
                         var firstOrDefault = schemeExes.FirstOrDefault(x => x.ValidSchemeHost &&
-                                                                      x.Scheme.ToLower().Equals(schemeHandler.Scheme.Scheme.ToLower()) &&
-                                                                      x.Host.ToLower().Equals(schemeHandler.Scheme.Host.ToLower()));
+                                                                      x.Scheme.Equals(schemeHandler.Scheme.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                                                                      x.Host.Equals(schemeHandler.Scheme.Host, StringComparison.OrdinalIgnoreCase));
                         if (firstOrDefault is null)
                         {
                             schemeExes.Add(new UrlSchemeEx(schemeHandler.Scheme, schemeHandler.IsCorsEnabled, schemeHandler.IsSecure));

--- a/src/Chromely/Browser/CefSettingsExtension.cs
+++ b/src/Chromely/Browser/CefSettingsExtension.cs
@@ -27,7 +27,7 @@ internal static class CefSettingsExtension
                 continue;
             }
 
-            switch (setting.Key.ToUpper())
+            switch (setting.Key.ToUpperInvariant())
             {
                 case CefSettingKeys.NOSANDBOX:
                     if (setting.Value.TryParseBoolean(out boolResult))
@@ -111,7 +111,7 @@ internal static class CefSettingsExtension
                     break;
 
                 case CefSettingKeys.LOGSEVERITY:
-                    switch (setting.Value.ToUpper())
+                    switch (setting.Value.ToUpperInvariant())
                     {
                         case LogSeverityOption.DEFAULT:
                             cefSettings.LogSeverity = CefLogSeverity.Default;

--- a/src/Chromely/Browser/ClientAppUtils.cs
+++ b/src/Chromely/Browser/ClientAppUtils.cs
@@ -13,13 +13,13 @@ public enum ProcessType
 }
 
 /// <summary>
-/// Utility class to determine browser and child processes. 
+/// Utility class to determine browser and child processes.
 /// </summary>
 /// <remarks>
-/// CEF3 runs using multiple processes. The main process which handles window creation, 
-/// painting and network access is called the “browser” process. 
-/// This is generally the same process as the host application 
-/// and the majority of the application logic will run in the browser process. 
+/// CEF3 runs using multiple processes. The main process which handles window creation,
+/// painting and network access is called the “browser” process.
+/// This is generally the same process as the host application
+/// and the majority of the application logic will run in the browser process.
 ///
 /// Reference - https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage
 /// </remarks>
@@ -85,7 +85,7 @@ public static class ClientAppUtils
     /// <returns>true if it has argument, otherwise false.</returns>
     private static bool HasArgument(IEnumerable<string> args, string argType)
     {
-        return args.Any(a => a.StartsWith(argType));
+        return args.Any(a => a.StartsWith(argType, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -98,7 +98,7 @@ public static class ClientAppUtils
     {
         if (args is not null)
         {
-            var arg = args.FirstOrDefault(a => a.StartsWith(argumentName));
+            var arg = args.FirstOrDefault(a => a.StartsWith(argumentName, StringComparison.Ordinal));
             if (arg is not null)
             {
                 return arg.Split('=').Last();

--- a/src/Chromely/Browser/Handlers/DefaultExternalRequestSchemeHandler.cs
+++ b/src/Chromely/Browser/Handlers/DefaultExternalRequestSchemeHandler.cs
@@ -32,7 +32,7 @@ public class DefaultExternalRequestSchemeHandler : DefaultAsyncHandlerBase
     /// </summary>
     protected virtual HttpMethod GetHttpMethod(string methodName)
     {
-        return methodName.ToUpper() switch
+        return methodName.ToUpperInvariant() switch
         {
             "GET" => HttpMethod.Get,
             "PUT" => HttpMethod.Put,

--- a/src/Chromely/Loader/CefLoader.cs
+++ b/src/Chromely/Loader/CefLoader.cs
@@ -15,7 +15,7 @@ namespace Chromely.Loader;
 /// Note:
 /// Keep this class in a separate nuget package
 /// due to additional reference to ICSharpCode.SharpZipLib.
-/// Not everyone will be glad about this. 
+/// Not everyone will be glad about this.
 /// </summary>
 public class CefLoader
 {
@@ -123,7 +123,7 @@ public class CefLoader
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="platform"></param>
     /// <param name="processArchitecture"></param>
@@ -134,7 +134,7 @@ public class CefLoader
         var arch = processArchitecture.ToString()
             .Replace("X64", "64")
             .Replace("X86", "32");
-        var platformIdentifier = (platform + arch).ToLower();
+        var platformIdentifier = (platform + arch).ToLowerInvariant();
         var indexUrl = CefBuildsDownloadIndex(platformIdentifier);
 
         // cef_binary_3.3626.1895.g7001d56_windows64_client.tar.bz2
@@ -163,7 +163,7 @@ public class CefLoader
                 return found.Groups[1].Value;
             }
 
-            #region https://github.com/chromelyapps/Chromely/issues/257 
+            #region https://github.com/chromelyapps/Chromely/issues/257
 
             // Hack until fixed.
             if (!string.IsNullOrEmpty(binaryNamePattern1))
@@ -249,7 +249,7 @@ public class CefLoader
 
             Logger.Instance.Log.LogInformation("CefLoader: Parallel download {_archiveName}, {_downloadLength / (1024 * 1024)}MB", _archiveName, _downloadLength);
 
-            // Calculate ranges  
+            // Calculate ranges
             var readRanges = new List<Range>();
             for (var chunk = 0; chunk < _numberOfParallelDownloads - 1; chunk++)
             {

--- a/src/Chromely/NativeHosts/WinHost/WinBase/NativeHostBase.cs
+++ b/src/Chromely/NativeHosts/WinHost/WinBase/NativeHostBase.cs
@@ -409,7 +409,7 @@ public abstract partial class NativeHostBase : IChromelyNativeHost
             {
                 var assembly = Assembly.GetEntryAssembly();
                 var iconAsResource = assembly?.GetManifestResourceNames()
-                    .FirstOrDefault(res => res.EndsWith(_options.RelativePathToIconFile));
+                    .FirstOrDefault(res => res.EndsWith(_options.RelativePathToIconFile, StringComparison.Ordinal));
                 if (iconAsResource is not null)
                 {
                     using var resStream = assembly.GetManifestResourceStream(iconAsResource);


### PR DESCRIPTION
This commit fixes [CA1304](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1304) warning during build. Also, it reduces number of allocations when comparing using lower register and improves performance by using OrdinalComparison where possible instead of culture-specific comparison.